### PR TITLE
fix: Fix docker vs local environments

### DIFF
--- a/CSharp/.template.config/template.json
+++ b/CSharp/.template.config/template.json
@@ -160,6 +160,20 @@
             "valueTransform": "kebabCaseTransformer",
             "replaces": "$(kebab_appname)",
             "description": "Create a kebab case name from the app name"
+        },
+        "appUpperName": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "upperCaseTransformer",
+            "replaces": "$(upper_appname)",
+            "description": "Create an upper case name from the app name"
+        },
+        "appLowerName": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "lowerCaseTransformer",
+            "replaces": "$(lower_appname)",
+            "description": "Create an upper case name from the app name"
         }
     },
     "sources": [
@@ -226,10 +240,11 @@
                 {
                     "condition": "(!docker)",
                     "exclude": [
-                        "src/docker-compose.yml",
+                        "src/docker-compose.*",
                         "src/Dockerfile",
                         "src/Dockerfile*",
                         "src/.env",
+                        "src/.env.dev",
                         "src/.dockerignore"
                     ]
                 },
@@ -299,6 +314,12 @@
     },
     "kebabCaseTransformer": {
       "identifier": "kebabCase"
+    },
+    "upperCaseTransformer": {
+      "identifier": "upperCase"
+    },
+    "lowerCaseTransformer": {
+      "identifier": "lowerCase"
     }
   }
 }

--- a/CSharp/README.md
+++ b/CSharp/README.md
@@ -28,8 +28,9 @@ life easier\
 
 ## Getting Started
 
+- Commit your code to source control (e.g. `feat(all): Initial infrastructure`)
 - Add your continuous integration assets (e.g. azure-pipeline.yml)
-- Commit your code to source control (e.g. `feat(all): Initial commit`)
+- Commit your code to source control (e.g. `chore(build): Add build/release assets`)
 - Create your query & commands models in the Api project
 //#if efcore
 - Setup `IEntityConfiguration<TModel>` classes for any query contracts and
@@ -58,9 +59,9 @@ life easier\
    _just be sure to setup your own request handler to generate this fake data_
 //#if docker
 - Run `docker-compose up` from the src directory.\
-  _the webapi image depends on the db image. However, it could take a little bit_
-  _for the database to start. That will throw an error when the webapi starts up._
-  _I would suggest running `docker-compose up -d db` first and wait._
+  _the webapi image depends on the db image. However, if you have a local sql
+  _server you would like to use instead, you can change the "db" server name_
+  _to "host.docker.internal" to target your host machine database_
 //#endif
 //#if (!docker)
 - Run `dotnet watch run`

--- a/CSharp/README.md
+++ b/CSharp/README.md
@@ -28,7 +28,7 @@ life easier\
 
 ## Getting Started
 
-- Commit your code to source control (e.g. `feat(all): Initial infrastructure`)
+- Commit your code to source control (e.g. `feat(all): Add initial infrastructure`)
 - Add your continuous integration assets (e.g. azure-pipeline.yml)
 - Commit your code to source control (e.g. `chore(build): Add build/release assets`)
 - Create your query & commands models in the Api project

--- a/CSharp/src/.config/dotnet-tools.json
+++ b/CSharp/src/.config/dotnet-tools.json
@@ -2,7 +2,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "5.0.0",
+      "version": "5.0.3",
       "commands": [
         "dotnet-ef"
       ]

--- a/CSharp/src/.env
+++ b/CSharp/src/.env
@@ -1,3 +1,9 @@
 # TO ONLY BE USED FOR NON PRIVATE DEV VARIABLES!!!!
 
-COMPOSE_PROJECT_NAME="project_$(kebab_appname)"
+COMPOSE_PROJECT_NAME="project_$(lower_appname)"
+BUILD_ARTIFACTSTAGINGDIRECTORY="."
+$(upper_appname)_WEBAPI__HTTP_PORT="5000"
+$(upper_appname)_WEBAPI__HTTPS_PORT="5001"
+$(upper_appname)_DB__SAPASSWORD="foobar123@!3A"
+$(upper_appname)_DB__PORT="1433"
+$(upper_appname)_CONNECTIONSTRINGS__MAIN="Server=db;User Id=sa;Password=foobar123@!3A;Initial Catalog=BusinessApp"

--- a/CSharp/src/BusinessApp.Infrastructure.WebApi.FunctionalTest/RoutingBootstrapperTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.WebApi.FunctionalTest/RoutingBootstrapperTests.cs
@@ -58,8 +58,8 @@ namespace BusinessApp.Infrastructure.WebApi.FunctionalTest
             var accessHeader = Assert.Single(
                 response.Headers.GetValues("Access-Control-Expose-Headers"));
             var pageHeader = Assert.Single(
-                response.Headers.GetValues("VND.parkeremg.pagination"));
-            Assert.Equal("VND.parkeremg.pagination", accessHeader);
+                response.Headers.GetValues("VND.foobar.pagination"));
+            Assert.Equal("VND.foobar.pagination", accessHeader);
             Assert.Equal("count=1", pageHeader);
         }
 

--- a/CSharp/src/BusinessApp.Infrastructure.WebApi.FunctionalTest/WebApplicationFactoryExtensions.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.WebApi.FunctionalTest/WebApplicationFactoryExtensions.cs
@@ -32,18 +32,19 @@ namespace BusinessApp.Infrastructure.WebApi.FunctionalTest
             var client = factory
                 .WithWebHostBuilder(builder =>
                 {
-                    builder.ConfigureAppConfiguration((hostingContext, config) =>
+                    _ = builder.ConfigureAppConfiguration((hostingContext, config) =>
                     {
-                        config.AddJsonFile("appsettings.test.json");
+                        _ = config.AddJsonFile("appsettings.test.json")
+                            .AddEnvironmentVariables(prefix: "StaticForms_");
                     })
                     .ConfigureServices(services =>
                     {
-                        services.AddSingleton(container);
+                        _ = services.AddSingleton(container);
                     })
                     .ConfigureTestServices(services =>
                     {
                         configuringServices?.Invoke(container);
-                        services.AddAuthentication(AuthenticationScheme)
+                        _ = services.AddAuthentication(AuthenticationScheme)
                                 .AddScheme<AuthenticationSchemeOptions, FakeAuthenticationHandler>
                                 (AuthenticationScheme, options => { });
 
@@ -71,7 +72,7 @@ namespace BusinessApp.Infrastructure.WebApi.FunctionalTest
                 UrlEncoder
                 encoder,
                 ISystemClock clock) : base(options, logger, encoder, clock)
-            {}
+            { }
 
             protected override Task<AuthenticateResult> HandleAuthenticateAsync()
             {

--- a/CSharp/src/BusinessApp.Infrastructure.WebApi/EnvelopeQueryResourceHandler.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.WebApi/EnvelopeQueryResourceHandler.cs
@@ -35,9 +35,15 @@ namespace BusinessApp.Infrastructure.WebApi
                 : await handler.HandleAsync(query, cancelToken)
                 .MapAsync(envelope =>
                 {
-                    context.Response.Headers.Add("Access-Control-Expose-Headers", new[] { "VND.parkeremg.pagination" });
-                    context.Response.Headers.Add("VND.parkeremg.pagination",
+#if !DEBUG
+                    context.Response.Headers.Add("Access-Control-Expose-Headers", new[] { "VND.$(lower_appname).pagination" });
+                    context.Response.Headers.Add("VND.$(lower_appname).pagination",
                         new StringValues(envelope.Pagination.ToHeaderValue()));
+#else
+                    context.Response.Headers.Add("Access-Control-Expose-Headers", new[] { "VND.foobar.pagination" });
+                    context.Response.Headers.Add("VND.foobar.pagination",
+                        new StringValues(envelope.Pagination.ToHeaderValue()));
+#endif
 
                     return HandlerContext.Create(query, envelope.Data);
                 });

--- a/CSharp/src/BusinessApp.Test.Shared/DatabaseFixture.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/DatabaseFixture.cs
@@ -31,6 +31,7 @@ namespace BusinessApp.Test.Shared
                 .ConfigureAppConfiguration((_, builder) =>
                 {
                     builder.AddJsonFile("appsettings.test.json");
+                    builder.AddEnvironmentVariables(prefix: "StaticForms_");
                 })
                 .UseStartup<Startup>()
                 .Build()

--- a/CSharp/src/BusinessApp.WebApi/.env.docker
+++ b/CSharp/src/BusinessApp.WebApi/.env.docker
@@ -1,3 +1,0 @@
-# TO ONLY BE USED FOR NON PRIVATE DEV VARIABLES!!!!
-
-SQLCONNSTR_BUSINESSAPPLICATION="Server=172.20.128.2;Initial Catalog=BusinessApp;User Id=sa;Password=foobar123@!3A"

--- a/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
+++ b/CSharp/src/BusinessApp.WebApi/BusinessApp.WebApi.csproj
@@ -4,7 +4,6 @@
     <Product>BusinessApp Web Api</Product>
     <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>59121fd6-5ba7-4456-93e6-56dd3e6a2a8e</UserSecretsId>
-    <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
     <IsPackable>false</IsPackable>
 <!--#if (description != '')-->
     <Description>$(product_description)</Description>
@@ -30,7 +29,7 @@
 <!--#if (efcore)-->
   <Target Name="Create Migrations Script" AfterTargets="Publish" Condition="'$(Configuration)' == 'Release'">
       <Exec Command="dotnet tool restore" />
-      <Exec Command="dotnet tool run dotnet-ef migrations script --configuration $(Configuration) --no-build --idempotent --output $(build_artifactstagingdirectory)/migrations/BusinessAppDbContext.sql --context BusinessAppDbContext" />
+      <Exec Command="dotnet tool run dotnet-ef migrations script --configuration $(Configuration) --no-build --idempotent --output $(BUILD_ARTIFACTSTAGINGDIRECTORY)/migrations/BusinessAppDbContext.sql --context BusinessAppDbContext" />
   </Target>
 <!--#endif-->
 

--- a/CSharp/src/BusinessApp.WebApi/Properties/launchSettings.json
+++ b/CSharp/src/BusinessApp.WebApi/Properties/launchSettings.json
@@ -22,8 +22,7 @@
     "BusinessApp.WebApi": {
             "commandName": "Project",
             "launchBrowser": false,
-            "launchUrl": "api/values",
-             "applicationUrl": "https://localhost:5001;http://localhost:5000",
+            "applicationUrl": "https://localhost:5001;http://localhost:5000",
             "environmentVariables": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
             }

--- a/CSharp/src/Dockerfile
+++ b/CSharp/src/Dockerfile
@@ -6,19 +6,24 @@ EXPOSE 443
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
 COPY *.crt /usr/local/share/ca-certificates/
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 RUN update-ca-certificates
 
-# Just copy everything since we need to preserve dir structure & there is no other way to do it
+# Just copy everything since we need to preserve dir structure
+# & there is no other way to do it. This will slow things down
 WORKDIR /src
 COPY . .
-RUN rm *.crt
 RUN dotnet restore
 
 WORKDIR "/src/."
 RUN dotnet build -c Release -o /app/build
 
 FROM build AS publish
+ENV BUILD_ARTIFACTSTAGINGDIRECTORY=/app/publish
+# need args for migration script
+ARG $(upper_appname)_CONNECTIONSTRINGS__MAIN
+ENV $(upper_appname)_CONNECTIONSTRINGS__MAIN ${$(upper_appname)_CONNECTIONSTRINGS__MAIN}
 RUN dotnet publish -c Release -o /app/publish
 
 FROM base AS final

--- a/CSharp/src/Dockerfile.development
+++ b/CSharp/src/Dockerfile.development
@@ -1,14 +1,14 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 
-ENV ASPNETCORE_ENVIRONMENT=Development
-
 COPY *.crt /usr/local/share/ca-certificates/
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 RUN update-ca-certificates
 
 # Just copy everything since we need to preserve dir structure & there is no other way to do it
 WORKDIR /src
 COPY . .
-RUN rm *.crt
 RUN dotnet restore
-CMD ["dotnet", "run", "BusinessApp.WebApi"]
+
+WORKDIR /src/BusinessApp.WebApi
+CMD ["dotnet", "run"]

--- a/CSharp/src/NuGet.Config
+++ b/CSharp/src/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/CSharp/src/docker-compose.production.yml
+++ b/CSharp/src/docker-compose.production.yml
@@ -1,24 +1,24 @@
-version: "2.4"
+# do not forget to add a .env file
+version: "3.9"
 
 services:
   webapi:
     build:
       context: .
-      dockerfile: Dockerfile.development
-    image:  projects/$(lower_appname)/webapi:dev
-    command: dotnet watch run
-    volumes:
-      - .:/src
+      args:
+        $(upper_appname)_CONNECTIONSTRINGS__MAIN: "${$(upper_appname)_CONNECTIONSTRINGS__MAIN?}"
+    image:  projects/$(lower_appname)/webapi:latest
     ports:
-      - "${$(upper_appname)_WEBAPI__HTTP_PORT?}:5000"
-      - "${$(upper_appname)_WEBAPI__HTTPS_PORT?}:5001"
+      - "${$(upper_appname)_WEBAPI__HTTP_PORT?}:80"
+      - "${$(upper_appname)_WEBAPI__HTTPS_PORT?}:443"
     environment:
-      ASPNETCORE_ENVIRONMENT: "Development"
       $(upper_appname)_CONNECTIONSTRINGS__MAIN: "${$(upper_appname)_CONNECTIONSTRINGS__MAIN?}"
+    restart: always
     depends_on:
       - db
   db:
     image: "mcr.microsoft.com/mssql/server"
+    restart: always
     environment:
       SA_PASSWORD: "${$(upper_appname)_DB__SAPASSWORD?}"
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
* Remove `NuGet.Confg`, not needed anymore
* Add production docker-compose to separate out development vs using the actual
  image
* Add more env. variables for quicker development
* Add upper and lower case app name for env variables and docker config
* Change suggestion getting-started steps to commit before CI/CD assets.
  You may have to create a separate branch to test this first.
* Update dotnet ef tools, out of date and failing when creating app
* Add env. variables in test so that a docker setup can still use localdb in a windows
  ci environment