### PR TITLE
feat(ProblemDetail): Add generic keys for extensions

### DIFF
--- a/CSharp/src/BusinessApp.Infrastructure/ModelValidationException.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/ModelValidationException.cs
@@ -10,6 +10,7 @@ namespace BusinessApp.Infrastructure
     /// </summary>
     public class ModelValidationException : BusinessAppException, IEnumerable<MemberValidationException>
     {
+        public const string ValidationKey = "ValidationErrors";
         private readonly IEnumerable<MemberValidationException> memberErrors;
 
         public ModelValidationException(string modelMessage)
@@ -19,7 +20,7 @@ namespace BusinessApp.Infrastructure
             : base(message)
         {
             this.memberErrors = memberErrors.NotEmpty().Expect(nameof(memberErrors));
-            Data.Add("ValidationErrors", memberErrors.ToDictionary(e => e.MemberName, e => e.Errors));
+            Data.Add(ValidationKey, memberErrors.ToDictionary(e => e.MemberName, e => e.Errors));
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailFactoryTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailFactoryTests.cs
@@ -259,6 +259,309 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
                 Assert.Equal("", problem["bar"]);
             }
 
+#if DEBUG
+            [Fact]
+            public void BatchException_CompositeProblemReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<Exception>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.IsType<CompositeProblemDetail>(problem);
+            }
+
+            [Fact]
+            public void BatchException_ManyStatusesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<Exception>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Equal(200, p.StatusCode),
+                    p => Assert.Equal(500, p.StatusCode)
+                );
+            }
+
+            [Fact]
+            public void BatchException_ManyTypesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(new ProblemTypeExceptionStub())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Equal("about:blank", p.Type.ToString()),
+                    p => Assert.Equal("http://bar/foo.html", p.Type.ToString())
+                );
+            }
+
+            [Fact]
+            public void BatchException_ManyMessagesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(new ProblemTypeExceptionStub("msg from exception"))
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Null(p.Detail),
+                    p => Assert.Equal("msg from exception", p.Detail)
+                );
+            }
+
+            [Fact]
+            public void BatchException_ExceptionExtensionsAdded()
+            {
+                /* Arrange */
+                var innerError = new ProblemTypeExceptionStub();
+                innerError.Data.Add("foo", "bar");
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(innerError)
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.False(p.TryGetValue("foo", out object _)),
+                    p => Assert.Equal("bar", p["foo"])
+                );
+            }
+
+            [Theory]
+            [InlineData(1)]
+            [InlineData("")]
+            public void BatchExceptionIsAMixOfExceptionWithoutStringKey_ExtensionsNotAdded(
+                object key)
+            {
+                /* Arrange */
+                var innerError = new ProblemTypeExceptionStub();
+                innerError.Data.Add(key, "bar");
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(innerError)
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.False(problem.TryGetValue(key.ToString(), out object _));
+            }
+
+            [Fact]
+            public void BatchException_DetailMessagedAdded()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<ProblemTypeExceptionStub>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.Equal(
+                    "The request partially succeeded. Please review the errors before continuing",
+                    problem.Detail);
+            }
+#elif hasbatch
+            [Fact]
+            public void BatchException_CompositeProblemReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<Exception>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.IsType<CompositeProblemDetail>(problem);
+            }
+
+            [Fact]
+            public void BatchException_ManyStatusesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<Exception>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Equal(200, p.StatusCode),
+                    p => Assert.Equal(500, p.StatusCode)
+                );
+            }
+
+            [Fact]
+            public void BatchException_ManyTypesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(new ProblemTypeExceptionStub())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Equal("about:blank", p.Type.ToString()),
+                    p => Assert.Equal("http://bar/foo.html", p.Type.ToString())
+                );
+            }
+
+            [Fact]
+            public void BatchException_ManyMessagesReturned()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(new ProblemTypeExceptionStub("msg from exception"))
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.Null(p.Detail),
+                    p => Assert.Equal("msg from exception", p.Detail)
+                );
+            }
+
+            [Fact]
+            public void BatchException_ExceptionExtensionsAdded()
+            {
+                /* Arrange */
+                var innerError = new ProblemTypeExceptionStub();
+                innerError.Data.Add("foo", "bar");
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(innerError)
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                var problems = Assert.IsType<CompositeProblemDetail>(problem);
+                Assert.Collection<ProblemDetail>(problems,
+                    p => Assert.False(p.TryGetValue("foo", out object _)),
+                    p => Assert.Equal("bar", p["foo"])
+                );
+            }
+
+            [Theory]
+            [InlineData(1)]
+            [InlineData("")]
+            public void BatchExceptionIsAMixOfExceptionWithoutStringKey_ExtensionsNotAdded(
+                object key)
+            {
+                /* Arrange */
+                var innerError = new ProblemTypeExceptionStub();
+                innerError.Data.Add(key, "bar");
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(innerError)
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.False(problem.TryGetValue(key.ToString(), out object _));
+            }
+
+            [Fact]
+            public void BatchException_DetailMessagedAdded()
+            {
+                /* Arrange */
+                var results = new[]
+                {
+                    Result.Ok(),
+                    Result.Error(A.Dummy<ProblemTypeExceptionStub>())
+                };
+                var error = BatchException.FromResults(results);
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.Equal(
+                    "The request partially succeeded. Please review the errors before continuing",
+                    problem.Detail);
+            }
+#endif
         }
 
         private sealed class ProblemTypeExceptionStub : Exception

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetailFactory.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/ProblemDetailFactory.cs
@@ -61,8 +61,10 @@ namespace BusinessApp.WebApi.ProblemDetails
             {
                 foreach (DictionaryEntry entry in error.Data)
                 {
-                    var key = entry.Key.ToString() ?? "";
-                    _ = problem.TryAdd(key, entry.Value ?? "");
+                    var key = entry.Key.ToString() ?? CreateKey(option);
+                    _ = problem.TryAdd(
+                        string.IsNullOrWhiteSpace(key) ? CreateKey(option) : key,
+                        entry.Value ?? "");
                 }
             }
 
@@ -104,5 +106,12 @@ namespace BusinessApp.WebApi.ProblemDetails
             };
         }
 #endif
+
+    private static string CreateKey(ProblemDetailOptions options)
+        => options.StatusCode switch
+        {
+            400 => ModelValidationException.ValidationKey,
+            _ => "Errors"
+        };
     }
 }


### PR DESCRIPTION
Extensions come from an exceptions `Data` property. However, this can be
null or empty. If it is, use the status code to define a key so the
extension property is not serialized as an empty key.