### PR TITLE
refactor(events): Rename IDomainEvent to IEvent

### DIFF
--- a/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorEventPublisher.cs
+++ b/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorEventPublisher.cs
@@ -9,7 +9,7 @@ using SimpleInjector;
 namespace BusinessApp.CompositionRoot
 {
 #pragma warning disable IDE0065
-    using EventResult = Result<IEnumerable<IDomainEvent>, Exception>;
+    using EventResult = Result<IEnumerable<IEvent>, Exception>;
 #pragma warning restore IDE0065
 
     /// <summary>
@@ -23,7 +23,7 @@ namespace BusinessApp.CompositionRoot
             => this.container = container.NotNull().Expect(nameof(container));
 
         public Task<EventResult> PublishAsync<T>(T e, CancellationToken cancelToken)
-            where T : notnull, IDomainEvent
+            where T : notnull, IEvent
         {
             var handler = (EventHandler)Activator.CreateInstance(
                 typeof(GenericEventHandler<>).MakeGenericType(typeof(T)))!;
@@ -33,14 +33,14 @@ namespace BusinessApp.CompositionRoot
 
         private abstract class EventHandler
         {
-            public abstract Task<EventResult> HandleAsync(IDomainEvent request,
+            public abstract Task<EventResult> HandleAsync(IEvent request,
                 Container container, CancellationToken cancelToken);
         }
 
         private class GenericEventHandler<TEvent> : EventHandler
-              where TEvent : IDomainEvent
+              where TEvent : IEvent
         {
-            public override async Task<EventResult> HandleAsync(IDomainEvent @event,
+            public override async Task<EventResult> HandleAsync(IEvent @event,
                 Container container, CancellationToken cancelToken)
             {
                 var handlers = container.GetAllInstances<IEventHandler<TEvent>>();

--- a/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorProcessManager.cs
+++ b/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorProcessManager.cs
@@ -23,7 +23,7 @@ namespace BusinessApp.CompositionRoot
             this.store = store.NotNull().Expect(nameof(store));
         }
 
-        public async Task<Result<Unit, Exception>> HandleNextAsync(IEnumerable<IDomainEvent> events,
+        public async Task<Result<Unit, Exception>> HandleNextAsync(IEnumerable<IEvent> events,
             CancellationToken cancelToken)
         {
             var commands = await store.GetAllAsync();
@@ -60,14 +60,14 @@ namespace BusinessApp.CompositionRoot
 
         private abstract class CommandMapper
         {
-            public abstract void Map(object request, IDomainEvent @event, Container container);
+            public abstract void Map(object request, IEvent @event, Container container);
         }
 
         private class CommandMapper<R, E> : CommandMapper
             where R : notnull, new()
-            where E : IDomainEvent
+            where E : IEvent
         {
-            public override void Map(object request, IDomainEvent @event, Container container)
+            public override void Map(object request, IEvent @event, Container container)
             {
                 var mapper = container.GetInstance<IRequestMapper<R, E>>();
 

--- a/CSharp/src/BusinessApp.Infrastructure.IntegrationTest/EventMetadataPublisherFactoryTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.IntegrationTest/EventMetadataPublisherFactoryTests.cs
@@ -81,10 +81,10 @@ namespace BusinessApp.Infrastructure.IntegrationTest
                 {
                     CausationId = (MetadataId)3
                 };
-                var e = A.Dummy<IDomainEvent>();
+                var e = A.Dummy<IEvent>();
                 A.CallTo(() => store.Add(e)).Returns(trackingId);
                 A.CallTo(() => inner.PublishAsync(e, cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(new IDomainEvent[0]));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(new IEvent[0]));
 
                 /* Act */
                 var events = await publisher.PublishAsync(e, cancelToken);
@@ -97,10 +97,10 @@ namespace BusinessApp.Infrastructure.IntegrationTest
             public async Task HasEventOutcome_ThoseEventsReturns()
             {
                 /* Arrange */
-                var originalEvent = A.Dummy<IDomainEvent>();
-                var outcomes = A.CollectionOfDummy<IDomainEvent>(1);
+                var originalEvent = A.Dummy<IEvent>();
+                var outcomes = A.CollectionOfDummy<IEvent>(1);
                 A.CallTo(() => inner.PublishAsync(originalEvent, cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(outcomes));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(outcomes));
 
                 /* Act */
                 var events = await publisher.PublishAsync(originalEvent, cancelToken);
@@ -113,8 +113,8 @@ namespace BusinessApp.Infrastructure.IntegrationTest
             public async Task HasEventOutcome_OriginalEventIdSetAsCausationId()
             {
                 /* Arrange */
-                var originalEvent = A.Dummy<IDomainEvent>();
-                var outcomes = A.CollectionOfDummy<IDomainEvent>(1);
+                var originalEvent = A.Dummy<IEvent>();
+                var outcomes = A.CollectionOfDummy<IEvent>(1);
                 var firstTrackingId = new EventTrackingId((MetadataId)1, (MetadataId)2)
                 {
                     CausationId = (MetadataId)3
@@ -127,9 +127,9 @@ namespace BusinessApp.Infrastructure.IntegrationTest
                 A.CallTo(() => store.Add(originalEvent)).Returns(firstTrackingId);
                 A.CallTo(() => store.Add(outcomes.First())).Returns(nextTrackingId);
                 A.CallTo(() => inner.PublishAsync(originalEvent, cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(outcomes));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(outcomes));
                 A.CallTo(() => inner.PublishAsync(outcomes.First(), cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(A.CollectionOfDummy<IDomainEvent>(0)));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(A.CollectionOfDummy<IEvent>(0)));
                 var _ = await publisher.PublishAsync(originalEvent, cancelToken);
 
                 /* Act */
@@ -146,14 +146,14 @@ namespace BusinessApp.Infrastructure.IntegrationTest
             {
                 /* Arrange */
                 var error = new Exception();
-                A.CallTo(() => inner.PublishAsync(A<IDomainEvent>._, A<CancellationToken>._))
-                    .Returns(Result.Error<IEnumerable<IDomainEvent>>(error));
+                A.CallTo(() => inner.PublishAsync(A<IEvent>._, A<CancellationToken>._))
+                    .Returns(Result.Error<IEnumerable<IEvent>>(error));
 
                 /* Act */
-                var result = await publisher.PublishAsync(A.Dummy<IDomainEvent>(), cancelToken);
+                var result = await publisher.PublishAsync(A.Dummy<IEvent>(), cancelToken);
 
                 /* Assert */
-                Assert.Equal(Result.Error<IEnumerable<IDomainEvent>>(error), result);
+                Assert.Equal(Result.Error<IEnumerable<IEvent>>(error), result);
             }
         }
     }

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
@@ -170,14 +170,14 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataId()
             {
                 /* Arrange */
-                EventMetadata<DomainEventStub> metadata = null;
+                EventMetadata<EventStub> metadata = null;
                 var metadataId = A.Dummy<MetadataId>();
                 A.CallTo(() => idFactory.Create()).Returns(metadataId);
-                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
+                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
 
                 /* Act */
-                var _ = store.Add(A.Dummy<DomainEventStub>());
+                _ = store.Add(A.Dummy<EventStub>());
 
                 /* Assert */
                 Assert.Same(metadataId, metadata.Id);
@@ -187,12 +187,12 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataCorrelationId()
             {
                 /* Arrange */
-                EventMetadata<DomainEventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
+                EventMetadata<EventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
 
                 /* Act */
-                var _ = store.Add(A.Dummy<DomainEventStub>());
+                _ = store.Add(A.Dummy<EventStub>());
 
                 /* Assert */
                 Assert.Same(triggerId, metadata.CorrelationId);
@@ -202,13 +202,13 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataToTheEvent()
             {
                 /* Arrange */
-                var e = A.Dummy<DomainEventStub>();
-                EventMetadata<DomainEventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
+                var e = A.Dummy<EventStub>();
+                EventMetadata<EventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
 
                 /* Act */
-                var _ = store.Add(e);
+                _ = store.Add(e);
 
                 /* Assert */
                 Assert.Same(e, metadata.Event);
@@ -218,10 +218,10 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void ReturnsEventMetadataTrackingId()
             {
                 /* Arrange */
-                var e = new DomainEventStub();
-                EventMetadata<DomainEventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
+                var e = new EventStub();
+                EventMetadata<EventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
 
                 /* Act */
                 var id = store.Add(e);

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
@@ -16,7 +16,7 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
         private readonly IPrincipal user;
         private readonly BusinessAppDbContext db;
 
-        public EFEventStoreFactoryTests(DatabaseFixture fixture)
+        public EFEventStoreFactoryTests()
         {
             idFactory = A.Fake<IEntityIdFactory<MetadataId>>();
             db = A.Fake<BusinessAppDbContext>();
@@ -25,14 +25,10 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             sut = new EFEventStoreFactory(db, idFactory, user);
 
             A.CallTo(() => user.Identity.Name).Returns("foo");
-            A.CallTo(() => db.ChangeTracker).Returns(fixture.DbContext.ChangeTracker);
         }
 
         public class Constructor : EFEventStoreFactoryTests
         {
-            public Constructor(DatabaseFixture fixture) : base(fixture)
-            { }
-
             public static IEnumerable<object[]> InvalidCtorArgs => new[]
             {
                 new object[]
@@ -72,137 +68,86 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
 
         public class Create : EFEventStoreFactoryTests
         {
-            public Create(DatabaseFixture fixture) : base(fixture)
-            { }
-
-            public class WhenMetadataExists : EFEventStoreFactoryTests
+            [Fact]
+            public void SetsMetadataId()
             {
-                private readonly RequestStub trigger;
+                /* Arrange */
+                var id = A.Dummy<MetadataId>();
+                Metadata<object> metadata = null;
+                A.CallTo(() => idFactory.Create()).Returns(id);
+                A.CallTo(() => db.Add(A<Metadata<object>>._))
+                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                public WhenMetadataExists(DatabaseFixture fixture) : base(fixture)
-                {
-                    trigger = new RequestStub();
-                }
+                /* Act */
+                var _ = sut.Create(A.Dummy<object>());
 
-                [Fact]
-                public void NotAddedToDb()
-                {
-                    /* Arrange */
-                    var metadata = new Metadata<RequestStub>(A.Dummy<MetadataId>(),
-                        "user", MetadataType.Request, trigger);
-                    db.ChangeTracker.Context.Add(metadata);
-
-                    /* Act */
-                    _ = sut.Create(trigger);
-
-                    /* Assert */
-                    A.CallTo(() => db.Add(A<Metadata<RequestStub>>._)).MustNotHaveHappened();
-                }
-
-                [Fact]
-                public void CorrlelationIdIsMetadataId()
-                {
-                    /* Arrange */
-                    var id = new MetadataId(1);
-                    var metadata = new Metadata<RequestStub>(id, "user", MetadataType.Request,
-                        trigger);
-                    db.ChangeTracker.Context.Add(metadata);
-                    var store = sut.Create(trigger);
-
-                    /* Act */
-                    var trackingId = store.Add(A.Dummy<IEvent>());
-
-                    /* Assert */
-                    Assert.Same(id, trackingId.CorrelationId);
-                }
+                /* Assert */
+                Assert.Equal(id, metadata.Id);
             }
 
-            public class WhenMetadataDoesNotExist : EFEventStoreFactoryTests
+            [Theory]
+            [InlineData("foouser", "foouser")]
+            [InlineData(null, "Anonymous")]
+            public void SetsMetadataUsername(string identityName, string setName)
             {
-                public WhenMetadataDoesNotExist(DatabaseFixture fixture) : base(fixture)
-                { }
+                /* Arrange */
+                Metadata<object> metadata = null;
+                A.CallTo(() => user.Identity.Name).Returns(identityName);
+                A.CallTo(() => db.Add(A<Metadata<object>>._))
+                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                [Fact]
-                public void SetsMetadataId()
-                {
-                    /* Arrange */
-                    var id = A.Dummy<MetadataId>();
-                    Metadata<object> metadata = null;
-                    A.CallTo(() => idFactory.Create()).Returns(id);
-                    A.CallTo(() => db.Add(A<Metadata<object>>._))
-                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                /* Act */
+                var _ = sut.Create(A.Dummy<object>());
 
-                    /* Act */
-                    var _ = sut.Create(A.Dummy<object>());
+                /* Assert */
+                Assert.Equal(setName, metadata.Username);
+            }
 
-                    /* Assert */
-                    Assert.Equal(id, metadata.Id);
-                }
+            [Fact]
+            public void NullIdentity_SetsAnonymousUsername()
+            {
+                /* Arrange */
+                Metadata<object> metadata = null;
+                A.CallTo(() => user.Identity).Returns(null);
+                A.CallTo(() => db.Add(A<Metadata<object>>._))
+                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                [Theory]
-                [InlineData("foouser", "foouser")]
-                [InlineData(null, "Anonymous")]
-                public void SetsMetadataUsername(string identityName, string setName)
-                {
-                    /* Arrange */
-                    Metadata<object> metadata = null;
-                    A.CallTo(() => user.Identity.Name).Returns(identityName);
-                    A.CallTo(() => db.Add(A<Metadata<object>>._))
-                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                /* Act */
+                var _ = sut.Create(A.Dummy<object>());
 
-                    /* Act */
-                    _ = sut.Create(A.Dummy<object>());
+                /* Assert */
+                Assert.Equal(AnonymousUser.Name, metadata.Username);
+            }
 
-                    /* Assert */
-                    Assert.Equal(setName, metadata.Username);
-                }
+            [Fact]
+            public void SetsMetadataEventTriggerType()
+            {
+                /* Arrange */
+                Metadata<object> metadata = null;
+                A.CallTo(() => db.Add(A<Metadata<object>>._))
+                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                [Fact]
-                public void NullIdentity_SetsAnonymousUsername()
-                {
-                    /* Arrange */
-                    Metadata<object> metadata = null;
-                    A.CallTo(() => user.Identity).Returns(null);
-                    A.CallTo(() => db.Add(A<Metadata<object>>._))
-                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                /* Act */
+                var _ = sut.Create(A.Dummy<object>());
 
-                    /* Act */
-                    _ = sut.Create(A.Dummy<object>());
+                /* Assert */
+                Assert.Equal(MetadataType.EventTrigger.ToString(), metadata.TypeName);
+            }
 
-                    /* Assert */
-                    Assert.Equal(AnonymousUser.Name, metadata.Username);
-                }
+            [Fact]
+            public void SetsMetadataTrigger()
+            {
+                /* Arrange */
+                var trigger = A.Dummy<object>();
+                Metadata<object> metadata = null;
+                A.CallTo(() => db.Add(A<Metadata<object>>._))
+                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                [Fact]
-                public void SetsMetadataEventTriggerType()
-                {
-                    /* Arrange */
-                    Metadata<object> metadata = null;
-                    A.CallTo(() => db.Add(A<Metadata<object>>._))
-                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                /* Act */
+                var _ = sut.Create(trigger);
 
-                    /* Act */
-                    _ = sut.Create(A.Dummy<object>());
-
-                    /* Assert */
-                    Assert.Equal(MetadataType.EventTrigger.ToString(), metadata.TypeName);
-                }
-
-                [Fact]
-                public void SetsMetadataTrigger()
-                {
-                    /* Arrange */
-                    var trigger = A.Dummy<object>();
-                    Metadata<object> metadata = null;
-                    A.CallTo(() => db.Add(A<Metadata<object>>._))
-                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
-
-                    /* Act */
-                    _ = sut.Create(trigger);
-
-                    /* Assert */
-                    Assert.Same(trigger, metadata.Data);
-                }
+                /* Assert */
+                Assert.Same(trigger, metadata.Data);
             }
         }
 
@@ -211,7 +156,7 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             private readonly IEventStore store;
             private readonly MetadataId triggerId;
 
-            public Add(DatabaseFixture fixture) : base(fixture)
+            public Add()
             {
                 var trigger = A.Dummy<object>();
                 store = A.Fake<IEventStore>();
@@ -225,14 +170,14 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataId()
             {
                 /* Arrange */
-                EventMetadata<EventStub> metadata = null;
+                EventMetadata<DomainEventStub> metadata = null;
                 var metadataId = A.Dummy<MetadataId>();
                 A.CallTo(() => idFactory.Create()).Returns(metadataId);
-                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
+                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
 
                 /* Act */
-                _ = store.Add(A.Dummy<EventStub>());
+                var _ = store.Add(A.Dummy<DomainEventStub>());
 
                 /* Assert */
                 Assert.Same(metadataId, metadata.Id);
@@ -242,12 +187,12 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataCorrelationId()
             {
                 /* Arrange */
-                EventMetadata<EventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
+                EventMetadata<DomainEventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
 
                 /* Act */
-                _ = store.Add(A.Dummy<EventStub>());
+                var _ = store.Add(A.Dummy<DomainEventStub>());
 
                 /* Assert */
                 Assert.Same(triggerId, metadata.CorrelationId);
@@ -257,13 +202,13 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void SetsEventMetadataToTheEvent()
             {
                 /* Arrange */
-                var e = A.Dummy<EventStub>();
-                EventMetadata<EventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
+                var e = A.Dummy<DomainEventStub>();
+                EventMetadata<DomainEventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
 
                 /* Act */
-                _ = store.Add(e);
+                var _ = store.Add(e);
 
                 /* Assert */
                 Assert.Same(e, metadata.Event);
@@ -273,10 +218,10 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             public void ReturnsEventMetadataTrackingId()
             {
                 /* Arrange */
-                var e = new EventStub();
-                EventMetadata<EventStub> metadata = null;
-                A.CallTo(() => db.Add(A<EventMetadata<EventStub>>._))
-                    .Invokes(c => metadata = c.GetArgument<EventMetadata<EventStub>>(0));
+                var e = new DomainEventStub();
+                EventMetadata<DomainEventStub> metadata = null;
+                A.CallTo(() => db.Add(A<EventMetadata<DomainEventStub>>._))
+                    .Invokes(c => metadata = c.GetArgument<EventMetadata<DomainEventStub>>(0));
 
                 /* Act */
                 var id = store.Add(e);

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/EFEventStoreFactory.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/EFEventStoreFactory.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Security.Principal;
 using BusinessApp.Kernel;
 
@@ -23,29 +22,16 @@ namespace BusinessApp.Infrastructure.Persistence
 
         public IEventStore Create<T>(T eventTrigger) where T : class
         {
-            var existingMetadata = FindExistingMetadata(eventTrigger);
-
-            var id = existingMetadata?.Id ?? idFactory.Create();
-
-            var metadata = existingMetadata ?? new Metadata<T>(id,
+            var id = idFactory.Create();
+            var metadata = new Metadata<T>(id,
                 user.Identity?.Name ?? AnonymousUser.Name,
                 MetadataType.EventTrigger,
                 eventTrigger);
 
-            if (existingMetadata == null)
-            {
-                _ = db.Add(metadata);
-            }
+            _ = db.Add(metadata);
 
             return new EFEventStore(id, db, idFactory);
         }
-
-        private Metadata<T>? FindExistingMetadata<T>(T eventTrigger)
-            where T : class
-            => db.ChangeTracker
-                .Entries<Metadata<T>>()
-                .SingleOrDefault(c => c.Entity.Data.Equals(eventTrigger))
-                ?.Entity;
 
         private class EFEventStore : IEventStore
         {

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/EFEventStoreFactory.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/EFEventStoreFactory.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Principal;
 using BusinessApp.Kernel;
 
@@ -22,16 +23,29 @@ namespace BusinessApp.Infrastructure.Persistence
 
         public IEventStore Create<T>(T eventTrigger) where T : class
         {
-            var id = idFactory.Create();
-            var metadata = new Metadata<T>(id,
+            var existingMetadata = FindExistingMetadata(eventTrigger);
+
+            var id = existingMetadata?.Id ?? idFactory.Create();
+
+            var metadata = existingMetadata ?? new Metadata<T>(id,
                 user.Identity?.Name ?? AnonymousUser.Name,
                 MetadataType.EventTrigger,
                 eventTrigger);
 
-            _ = db.Add(metadata);
+            if (existingMetadata == null)
+            {
+                _ = db.Add(metadata);
+            }
 
             return new EFEventStore(id, db, idFactory);
         }
+
+        private Metadata<T>? FindExistingMetadata<T>(T eventTrigger)
+            where T : class
+            => db.ChangeTracker
+                .Entries<Metadata<T>>()
+                .SingleOrDefault(c => c.Entity.Data.Equals(eventTrigger))
+                ?.Entity;
 
         private class EFEventStore : IEventStore
         {
@@ -47,7 +61,7 @@ namespace BusinessApp.Infrastructure.Persistence
                 this.correlationId = correlationId;
             }
 
-            public EventTrackingId Add<T>(T @event) where T : notnull, IDomainEvent
+            public EventTrackingId Add<T>(T @event) where T : notnull, IEvent
             {
                 var eventId = idFactory.Create();
                 var id = new EventTrackingId(eventId, correlationId);

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.Infrastructure.Persistence
     /// </summary>
     public abstract class EventMetadataEntityConfiguration<T> :
         IEntityTypeConfiguration<EventMetadata<T>>
-        where T : class, IDomainEvent
+        where T : class, IEvent
     {
         protected abstract string TableName { get; }
 
@@ -41,11 +41,15 @@ namespace BusinessApp.Infrastructure.Persistence
                 .HasColumnType("datetimeoffset(0)")
                 .IsRequired();
 
-            builder.HasOne<Metadata>()
+            builder.HasOne<Metadata<T>>()
                 .WithOne()
-                .HasForeignKey<EventMetadata<T>>(e => e.CorrelationId);
+                .HasForeignKey<EventMetadata<T>>(e => e.CorrelationId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Restrict);
 
             var owned = builder.OwnsOne(o => o.Event);
+
+            owned.Ignore(o => o.OccurredUtc);
 
             ConfigureEvent(owned);
         }

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
@@ -41,15 +41,11 @@ namespace BusinessApp.Infrastructure.Persistence
                 .HasColumnType("datetimeoffset(0)")
                 .IsRequired();
 
-            builder.HasOne<Metadata<T>>()
+            builder.HasOne<Metadata>()
                 .WithOne()
-                .HasForeignKey<EventMetadata<T>>(e => e.CorrelationId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Restrict);
+                .HasForeignKey<EventMetadata<T>>(e => e.CorrelationId);
 
             var owned = builder.OwnsOne(o => o.Event);
-
-            owned.Ignore(o => o.OccurredUtc);
 
             ConfigureEvent(owned);
         }

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/AuthorizationRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/AuthorizationRequestDecoratorTests.cs
@@ -5,6 +5,7 @@ using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using BusinessApp.Kernel;
+using BusinessApp.Test.Shared;
 using FakeItEasy;
 using Xunit;
 

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/AutomationRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/AutomationRequestDecoratorTests.cs
@@ -81,7 +81,7 @@ namespace BusinessApp.Infrastructure.UnitTest
                 var _ = await sut.HandleAsync(query, cancelToken);
 
                 /* Assert */
-                A.CallTo(() => manager.HandleNextAsync(A<IEnumerable<IDomainEvent>>._, A<CancellationToken>._))
+                A.CallTo(() => manager.HandleNextAsync(A<IEnumerable<IEvent>>._, A<CancellationToken>._))
                     .MustNotHaveHappened();
             }
 

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/EntityNotFoundQueryDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/EntityNotFoundQueryDecoratorTests.cs
@@ -5,6 +5,7 @@ using FakeItEasy;
 using Xunit;
 using System.Threading;
 using BusinessApp.Kernel;
+using BusinessApp.Test.Shared;
 
 namespace BusinessApp.Infrastructure.UnitTest
 {

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/EventConsumingRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/EventConsumingRequestDecoratorTests.cs
@@ -121,9 +121,9 @@ namespace BusinessApp.Infrastructure.UnitTest
             public async Task EventCreatesMoreEvents_AllEventsPublished()
             {
                 /* Arrange */
-                var twoEvents = new[] { new DomainEventStub(), new DomainEventStub() };
-                IEnumerable<IDomainEvent> noEvents = A.CollectionOfDummy<IDomainEvent>(0);
-                var firstEventEvents = new[] { new DomainEventStub(), new DomainEventStub() };
+                var twoEvents = new[] { new EventStub(), new EventStub() };
+                IEnumerable<IEvent> noEvents = A.CollectionOfDummy<IEvent>(0);
+                var firstEventEvents = new[] { new EventStub(), new EventStub() };
                 var @event = new CompositeEventStub
                 {
                     Events = twoEvents.ToList()
@@ -131,7 +131,7 @@ namespace BusinessApp.Infrastructure.UnitTest
                 A.CallTo(() => inner.HandleAsync(request, cancelToken))
                     .Returns(Result.Ok(@event));
                 A.CallTo(() => publisher.PublishAsync(twoEvents.First(), cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(firstEventEvents));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(firstEventEvents));
                 A.CallTo(() => publisher.PublishAsync(twoEvents.Last(), cancelToken))
                     .Returns(Result.Ok(noEvents));
                 A.CallTo(() => publisher.PublishAsync(firstEventEvents.First(), cancelToken))
@@ -154,8 +154,8 @@ namespace BusinessApp.Infrastructure.UnitTest
             public async Task AtLeastOnEventErrored_ErrorReturned()
             {
                 var exception = new Exception();
-                var noEvents = A.CollectionOfDummy<DomainEventStub>(0);
-                var twoEvents = new[] { new DomainEventStub(), new DomainEventStub() };
+                var noEvents = A.CollectionOfDummy<EventStub>(0);
+                var twoEvents = new[] { new EventStub(), new EventStub() };
                 var @event = new CompositeEventStub
                 {
                     Events = twoEvents
@@ -163,9 +163,9 @@ namespace BusinessApp.Infrastructure.UnitTest
                 A.CallTo(() => inner.HandleAsync(request, cancelToken))
                     .Returns(Result.Ok(@event));
                 A.CallTo(() => publisher.PublishAsync(twoEvents.First(), cancelToken))
-                    .Returns(Result.Ok<IEnumerable<IDomainEvent>>(noEvents));
+                    .Returns(Result.Ok<IEnumerable<IEvent>>(noEvents));
                 A.CallTo(() => publisher.PublishAsync(twoEvents.Last(), cancelToken))
-                    .Returns(Result.Error<IEnumerable<IDomainEvent>>(exception));
+                    .Returns(Result.Error<IEnumerable<IEvent>>(exception));
 
                 /* Act */
                 var handlerResult = await sut.HandleAsync(request, cancelToken);

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/EventMetadataTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/EventMetadataTests.cs
@@ -14,14 +14,14 @@ namespace BusinessApp.Infrastructure.UnitTest
             public static IEnumerable<object[]> InvalidArgs => new[]
             {
                 new object[] { null, A.Dummy<EventTrackingId>() },
-                new object[] { A.Dummy<DomainEventStub>(), null},
+                new object[] { A.Dummy<EventStub>(), null},
             };
 
             [Theory, MemberData(nameof(InvalidArgs))]
-            public void InvalidArgs_ExceptionThrown(DomainEventStub e, EventTrackingId i)
+            public void InvalidArgs_ExceptionThrown(EventStub e, EventTrackingId i)
             {
                 /* Arrange */
-                void shouldThrow() => new EventMetadata<DomainEventStub>(i, e);
+                void shouldThrow() => new EventMetadata<EventStub>(i, e);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -35,9 +35,9 @@ namespace BusinessApp.Infrastructure.UnitTest
             {
                 /* Arrange */
                 var i = A.Dummy<EventTrackingId>();
-                var e = A.Fake<DomainEventStub>();
+                var e = A.Fake<EventStub>();
                 A.CallTo(() => e.ToString()).Returns(null);
-                void shouldThrow() => new EventMetadata<DomainEventStub>(i, e);
+                void shouldThrow() => new EventMetadata<EventStub>(i, e);
 
                 /* Act */
                 var ex = Record.Exception(shouldThrow);
@@ -51,10 +51,10 @@ namespace BusinessApp.Infrastructure.UnitTest
             public void EventArg_EventPropertySet()
             {
                 /* Arrange */
-                var @event = A.Dummy<DomainEventStub>();
+                var @event = A.Dummy<EventStub>();
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(A.Dummy<EventTrackingId>(), @event);
+                var sut = new EventMetadata<EventStub>(A.Dummy<EventTrackingId>(), @event);
 
                 /* Assert */
                 Assert.Same(@event, sut.Event);
@@ -64,11 +64,11 @@ namespace BusinessApp.Infrastructure.UnitTest
             public void EventArg_EventNamePropertySet()
             {
                 /* Arrange */
-                var @event = A.Fake<DomainEventStub>();
+                var @event = A.Fake<EventStub>();
                 A.CallTo(() => @event.ToString()).Returns("foobar");
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(A.Dummy<EventTrackingId>(), @event);
+                var sut = new EventMetadata<EventStub>(A.Dummy<EventTrackingId>(), @event);
 
                 /* Assert */
                 Assert.Equal("foobar", sut.EventName);
@@ -79,13 +79,13 @@ namespace BusinessApp.Infrastructure.UnitTest
             {
                 /* Arrange */
                 var now = DateTimeOffset.UtcNow;
-                var @event = new DomainEventStub()
+                var @event = new EventStub()
                 {
                     OccurredUtc = now
                 };
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(A.Dummy<EventTrackingId>(), @event);
+                var sut = new EventMetadata<EventStub>(A.Dummy<EventTrackingId>(), @event);
 
                 /* Assert */
                 Assert.Equal(now, sut.OccurredUtc);
@@ -99,7 +99,7 @@ namespace BusinessApp.Infrastructure.UnitTest
                 var id = new EventTrackingId(eventId, A.Dummy<MetadataId>());
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(id, A.Dummy<DomainEventStub>());
+                var sut = new EventMetadata<EventStub>(id, A.Dummy<EventStub>());
 
                 /* Assert */
                 Assert.Same(eventId, sut.Id);
@@ -113,7 +113,7 @@ namespace BusinessApp.Infrastructure.UnitTest
                 var id = new EventTrackingId(A.Dummy<MetadataId>(), correlationId);
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(id, A.Dummy<DomainEventStub>());
+                var sut = new EventMetadata<EventStub>(id, A.Dummy<EventStub>());
 
                 /* Assert */
                 Assert.Same(correlationId, sut.CorrelationId);
@@ -130,7 +130,7 @@ namespace BusinessApp.Infrastructure.UnitTest
                 };
 
                 /* Act */
-                var sut = new EventMetadata<DomainEventStub>(id, A.Dummy<DomainEventStub>());
+                var sut = new EventMetadata<EventStub>(id, A.Dummy<EventStub>());
 
                 /* Assert */
                 Assert.Same(causationId, sut.CausationId);

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/InstanceCacheQueryDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/InstanceCacheQueryDecoratorTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System.Threading;
 using BusinessApp.Kernel;
 using System;
+using BusinessApp.Test.Shared;
 
 namespace BusinessApp.Infrastructure.UnitTest
 {

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/RequestExceptionDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/RequestExceptionDecoratorTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System.Threading;
 using BusinessApp.Kernel;
 using System;
+using BusinessApp.Test.Shared;
 
 namespace BusinessApp.Infrastructure.UnitTest
 {

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/SingleQueryRequestAdapterTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/SingleQueryRequestAdapterTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using BusinessApp.Kernel;
+using BusinessApp.Test.Shared;
 using FakeItEasy;
 using Xunit;
 

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/Stubs.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/Stubs.cs
@@ -9,7 +9,7 @@ namespace BusinessApp.Infrastructure.UnitTest
 #if DEBUG
     public class CompositeEventStub : ICompositeEvent
     {
-        public IEnumerable<IDomainEvent> Events { get; set; } = new List<IDomainEvent>();
+        public IEnumerable<IEvent> Events { get; set; } = new List<IEvent>();
     }
 #elif events
     public class CompositeEventStub : ICompositeEvent
@@ -58,7 +58,4 @@ namespace BusinessApp.Infrastructure.UnitTest
             }
         }
     }
-
-    public class ResponseStub
-    {}
 }

--- a/CSharp/src/BusinessApp.Infrastructure.UnitTest/ValidationRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.UnitTest/ValidationRequestDecoratorTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System.Threading;
 using BusinessApp.Kernel;
 using System;
+using BusinessApp.Test.Shared;
 
 namespace BusinessApp.Infrastructure.UnitTest
 {

--- a/CSharp/src/BusinessApp.Infrastructure/EventConsumingRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/EventConsumingRequestDecorator.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace BusinessApp.Infrastructure
 {
 #pragma warning disable IDE0065
-    using EventResult = Result<IEnumerable<IDomainEvent>, Exception>;
+    using EventResult = Result<IEnumerable<IEvent>, Exception>;
 #pragma warning restore IDE0065
 
     /// <summary>
@@ -53,12 +53,12 @@ namespace BusinessApp.Infrastructure
         }
 
         private async Task<EventResult> ConsumeAsync(
-            IEventPublisher publisher, IEnumerable<IDomainEvent> events, CancellationToken cancelToken)
+            IEventPublisher publisher, IEnumerable<IEvent> events, CancellationToken cancelToken)
         {
             var consumedEvents = events.Select(s => s).ToList();
 
             return !consumedEvents.Any()
-                ? Result.Ok<IEnumerable<IDomainEvent>>(consumedEvents)
+                ? Result.Ok<IEnumerable<IEvent>>(consumedEvents)
                 : await Task.WhenAll(consumedEvents.Select(e => PublishAsync(publisher, e, cancelToken)))
                     .CollectAsync()
                     .MapAsync(v => v.SelectMany(s => s))
@@ -66,7 +66,7 @@ namespace BusinessApp.Infrastructure
                     .MapAsync(e => consumedEvents.Concat(e));
         }
 
-        public Task<EventResult> PublishAsync(IEventPublisher publisher, IDomainEvent @event,
+        public Task<EventResult> PublishAsync(IEventPublisher publisher, IEvent @event,
             CancellationToken cancelToken)
         {
             var generic = publishMethod.MakeGenericMethod(@event.GetType());

--- a/CSharp/src/BusinessApp.Infrastructure/EventMetadata.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/EventMetadata.cs
@@ -13,7 +13,7 @@ namespace BusinessApp.Infrastructure
         { }
 #nullable restore
 
-        public EventMetadata(EventTrackingId id, IDomainEvent e)
+        public EventMetadata(EventTrackingId id, IEvent e)
         {
             Id = id.NotNull().Expect(nameof(id)).Id;
             CorrelationId = id.CorrelationId;
@@ -35,7 +35,7 @@ namespace BusinessApp.Infrastructure
     /// Model to store event metadata.
     /// </summary>
     public class EventMetadata<T> : EventMetadata
-        where T : notnull, IDomainEvent
+        where T : notnull, IEvent
     {
 #nullable disable
         private EventMetadata()

--- a/CSharp/src/BusinessApp.Infrastructure/EventMetadataPublisherFactory.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/EventMetadataPublisherFactory.cs
@@ -31,7 +31,7 @@ namespace BusinessApp.Infrastructure
 
         private class EventMetadataPublisher : IEventPublisher
         {
-            private readonly ConcurrentDictionary<IDomainEvent, EventTrackingId> outcomeTracking;
+            private readonly ConcurrentDictionary<IEvent, EventTrackingId> outcomeTracking;
             private readonly IEventPublisher inner;
             private readonly IEventStore store;
 
@@ -39,11 +39,11 @@ namespace BusinessApp.Infrastructure
             {
                 this.inner = inner.NotNull().Expect(nameof(inner));
                 this.store = store.NotNull().Expect(nameof(store));
-                outcomeTracking = new ConcurrentDictionary<IDomainEvent, EventTrackingId>();
+                outcomeTracking = new ConcurrentDictionary<IEvent, EventTrackingId>();
             }
 
-            public Task<Result<IEnumerable<IDomainEvent>, Exception>> PublishAsync<T>(
-                T @event, CancellationToken cancelToken) where T : IDomainEvent
+            public Task<Result<IEnumerable<IEvent>, Exception>> PublishAsync<T>(
+                T @event, CancellationToken cancelToken) where T : IEvent
                 => inner.PublishAsync(@event, cancelToken)
                     .AndThenAsync(o => TrackOutcomes(@event, o));
 
@@ -51,9 +51,9 @@ namespace BusinessApp.Infrastructure
             /// Add the current event to the store and track unpublished events
             /// so we can associate causation id
             /// </summary>
-            private Result<IEnumerable<IDomainEvent>, Exception> TrackOutcomes<T>(
-                T published, IEnumerable<IDomainEvent> outcomes)
-                where T : IDomainEvent
+            private Result<IEnumerable<IEvent>, Exception> TrackOutcomes<T>(
+                T published, IEnumerable<IEvent> outcomes)
+                where T : IEvent
             {
                 var publishedTrackingId = store.Add(published);
 

--- a/CSharp/src/BusinessApp.Infrastructure/IProcessManager.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/IProcessManager.cs
@@ -12,7 +12,7 @@ namespace BusinessApp.Infrastructure
     /// </summary>
     public interface IProcessManager
     {
-        Task<Result<Unit, Exception>> HandleNextAsync(IEnumerable<IDomainEvent> events,
+        Task<Result<Unit, Exception>> HandleNextAsync(IEnumerable<IEvent> events,
             CancellationToken cancelToken);
     }
 }

--- a/CSharp/src/BusinessApp.Infrastructure/IRequestMapper.cs
+++ b/CSharp/src/BusinessApp.Infrastructure/IRequestMapper.cs
@@ -10,7 +10,7 @@ namespace BusinessApp.Infrastructure
     /// </remarks>
     public interface IRequestMapper<TRequest, TEvent>
         where TRequest : notnull
-        where TEvent : IDomainEvent
+        where TEvent : IEvent
     {
         void Map(TRequest request, TEvent e);
     }

--- a/CSharp/src/BusinessApp.Kernel.UnitTest/CompositeEventTests.cs
+++ b/CSharp/src/BusinessApp.Kernel.UnitTest/CompositeEventTests.cs
@@ -35,7 +35,7 @@ namespace BusinessApp.Kernel.UnitTest
             public void HasEvents_ReturnsThoseEvents()
             {
                 /* Arrange */
-                var events = A.CollectionOfDummy<IDomainEvent>(2);
+                var events = A.CollectionOfDummy<IEvent>(2);
 
                 /* Act */
                 var @event = new CompositeEvent(events);

--- a/CSharp/src/BusinessApp.Kernel/CompositeEvent.cs
+++ b/CSharp/src/BusinessApp.Kernel/CompositeEvent.cs
@@ -6,16 +6,16 @@ namespace BusinessApp.Kernel
     /// <summary>
     /// Composite pattern to represent many events
     /// </summary>
-    public class CompositeEvent : IEnumerable<IDomainEvent>
+    public class CompositeEvent : IEnumerable<IEvent>
     {
-        private readonly IEnumerable<IDomainEvent> events;
+        private readonly IEnumerable<IEvent> events;
 
-        public CompositeEvent() => events = new List<IDomainEvent>();
+        public CompositeEvent() => events = new List<IEvent>();
 
-        public CompositeEvent(IEnumerable<IDomainEvent> events)
+        public CompositeEvent(IEnumerable<IEvent> events)
             => this.events = events.NotNull().Expect(nameof(events));
 
-        public IEnumerator<IDomainEvent> GetEnumerator() => events.GetEnumerator();
+        public IEnumerator<IEvent> GetEnumerator() => events.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/CSharp/src/BusinessApp.Kernel/ICompositeEvent.cs
+++ b/CSharp/src/BusinessApp.Kernel/ICompositeEvent.cs
@@ -7,6 +7,6 @@ namespace BusinessApp.Kernel
     /// </summary>
     public interface ICompositeEvent
     {
-        IEnumerable<IDomainEvent> Events { get; set; }
+        IEnumerable<IEvent> Events { get; set; }
     }
 }

--- a/CSharp/src/BusinessApp.Kernel/IEvent.cs
+++ b/CSharp/src/BusinessApp.Kernel/IEvent.cs
@@ -5,7 +5,7 @@ namespace BusinessApp.Kernel
     /// <summary>
     /// Represents event data
     /// </summary>
-    public interface IDomainEvent
+    public interface IEvent
     {
         DateTimeOffset OccurredUtc { get; }
     }

--- a/CSharp/src/BusinessApp.Kernel/IEventHandler.cs
+++ b/CSharp/src/BusinessApp.Kernel/IEventHandler.cs
@@ -6,13 +6,13 @@ using System.Threading.Tasks;
 namespace BusinessApp.Kernel
 {
 #pragma warning disable IDE0065
-    using HandlerResult = Result<IEnumerable<IDomainEvent>, Exception>;
+    using HandlerResult = Result<IEnumerable<IEvent>, Exception>;
 #pragma warning restore IDE0065
 
     /// <summary>
     /// Interface to handle event logic
     /// </summary>
-    public interface IEventHandler<TEvent> where TEvent : notnull, IDomainEvent
+    public interface IEventHandler<TEvent> where TEvent : notnull, IEvent
     {
         Task<HandlerResult> HandleAsync(TEvent e, CancellationToken cancelToken);
     }

--- a/CSharp/src/BusinessApp.Kernel/IEventPublisher.cs
+++ b/CSharp/src/BusinessApp.Kernel/IEventPublisher.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace BusinessApp.Kernel
 {
 #pragma warning disable IDE0065
-    using EventsResult = Result<IEnumerable<IDomainEvent>, System.Exception>;
+    using EventsResult = Result<IEnumerable<IEvent>, System.Exception>;
 #pragma warning restore IDE0065
 
     /// <summary>
@@ -14,6 +14,6 @@ namespace BusinessApp.Kernel
     public interface IEventPublisher
     {
         Task<EventsResult> PublishAsync<T>(T e, CancellationToken cancelToken)
-            where T : notnull, IDomainEvent;
+            where T : notnull, IEvent;
     }
 }

--- a/CSharp/src/BusinessApp.Kernel/IEventStore.cs
+++ b/CSharp/src/BusinessApp.Kernel/IEventStore.cs
@@ -8,6 +8,6 @@ namespace BusinessApp.Kernel
         /// <summary>
         /// Adds an event to the store
         /// </summary>
-        EventTrackingId Add<T>(T e) where T : notnull, IDomainEvent;
+        EventTrackingId Add<T>(T e) where T : notnull, IEvent;
     }
 }

--- a/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/BusinessAppTestDbContext.cs
@@ -75,7 +75,7 @@ namespace BusinessApp.Test.Shared
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
 #if DEBUG
-            modelBuilder.Entity<DomainEventStub>()
+            modelBuilder.Entity<EventStub>()
                 .Property(p => p.Id)
                 .HasConversion(id => id.ToInt64(null), val => new MetadataId(val));
 #elif events

--- a/CSharp/src/BusinessApp.Test.Shared/EventStub.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/EventStub.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using BusinessApp.Kernel;
 using FakeItEasy;
 
 namespace BusinessApp.Test.Shared
 {
-    public class DomainEventStub : IDomainEvent
+    public class EventStub : IEvent
     {
         public IEntityId Id { get; set; }
         public DateTimeOffset OccurredUtc { get; set; } = A.Dummy<DateTimeOffset>();
@@ -12,4 +12,3 @@ namespace BusinessApp.Test.Shared
         public string ToString(string format, IFormatProvider formatProvider) => "";
     }
 }
-

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
@@ -157,11 +157,9 @@ namespace BusinessApp.WebApi.IntegrationTest
             await response.Success(output);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 #if DEBUG
-            A.CallTo(() => notifier.Notify())
-                .MustHaveHappened(expectedCalls, Times.Exactly);
+            A.CallTo(() => notifier.Notify()).MustHaveHappenedOnceExactly();
 #elif events
-            A.CallTo(() => notifier.Notify())
-                .MustHaveHappened(expectedCalls, Times.Exactly);
+            A.CallTo(() => notifier.Notify()).MustHaveHappenedOnceExactly();
 #endif
         }
 
@@ -184,7 +182,9 @@ namespace BusinessApp.WebApi.IntegrationTest
                 Delete.WebDomainEvent e, CancellationToken cancelToken)
             {
                 tester.Notify();
-                return inner.HandleAsync(e, cancelToken);
+
+                return Task.FromResult(
+                    Result.Ok<IEnumerable<IEvent>>(Array.Empty<IEvent>()));
             }
         }
 #elif events

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
@@ -157,9 +157,11 @@ namespace BusinessApp.WebApi.IntegrationTest
             await response.Success(output);
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 #if DEBUG
-            A.CallTo(() => notifier.Notify()).MustHaveHappenedOnceExactly();
+            A.CallTo(() => notifier.Notify())
+                .MustHaveHappened(expectedCalls, Times.Exactly);
 #elif events
-            A.CallTo(() => notifier.Notify()).MustHaveHappenedOnceExactly();
+            A.CallTo(() => notifier.Notify())
+                .MustHaveHappened(expectedCalls, Times.Exactly);
 #endif
         }
 
@@ -182,9 +184,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                 Delete.WebDomainEvent e, CancellationToken cancelToken)
             {
                 tester.Notify();
-
-                return Task.FromResult(
-                    Result.Ok<IEnumerable<IEvent>>(Array.Empty<IEvent>()));
+                return inner.HandleAsync(e, cancelToken);
             }
         }
 #elif events
@@ -202,7 +202,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                 this.tester = tester;
             }
 
-            public Task<Result<IEnumerable<IDomainEvent>, System.Exception>> HandleAsync(
+            public Task<Result<IEnumerable<IEvent>, System.Exception>> HandleAsync(
                 Delete.WebDomainEvent e, CancellationToken cancelToken)
             {
                 tester.Notify();
@@ -228,8 +228,8 @@ namespace BusinessApp.WebApi.IntegrationTest
         private IDictionary<Type, HateoasLink<T, IEvent>> GetEventLinks<T>()
             => new Dictionary<Type, HateoasLink<T, IEvent>>();
 #elif (usehateoas && events)
-        private IDictionary<Type, HateoasLink<T, IDomainEvent>> GetEventLinks<T>()
-            => new Dictionary<Type, HateoasLink<T, IDomainEvent>>();
+        private IDictionary<Type, HateoasLink<T, IEvent>> GetEventLinks<T>()
+            => new Dictionary<Type, HateoasLink<T, IEvent>>();
 #endif
     }
 }

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/RouteTests.cs
@@ -180,7 +180,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                 this.tester = tester;
             }
 
-            public Task<Result<IEnumerable<IDomainEvent>, System.Exception>> HandleAsync(
+            public Task<Result<IEnumerable<IEvent>, System.Exception>> HandleAsync(
                 Delete.WebDomainEvent e, CancellationToken cancelToken)
             {
                 tester.Notify();
@@ -225,8 +225,8 @@ namespace BusinessApp.WebApi.IntegrationTest
         }
 
 #if DEBUG
-        private IDictionary<Type, HateoasLink<T, IDomainEvent>> GetEventLinks<T>()
-            => new Dictionary<Type, HateoasLink<T, IDomainEvent>>();
+        private IDictionary<Type, HateoasLink<T, IEvent>> GetEventLinks<T>()
+            => new Dictionary<Type, HateoasLink<T, IEvent>>();
 #elif (usehateoas && events)
         private IDictionary<Type, HateoasLink<T, IDomainEvent>> GetEventLinks<T>()
             => new Dictionary<Type, HateoasLink<T, IDomainEvent>>();

--- a/CSharp/src/BusinessApp.WebApi.IntegrationTest/ServiceRegistrationsTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.IntegrationTest/ServiceRegistrationsTests.cs
@@ -7,13 +7,10 @@ using BusinessApp.Infrastructure;
 using BusinessApp.Test.Shared;
 using System.Threading.Tasks;
 using System.Threading;
-using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
 using System;
-using SimpleInjector.Lifestyles;
 using BusinessApp.Kernel;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using BusinessApp.WebApi.Json;
 using Microsoft.Extensions.Localization;
 using BusinessApp.CompositionRoot;
@@ -155,7 +152,7 @@ namespace BusinessApp.WebApi.IntegrationTest
                     /* Arrange */
                     var hateoasType = typeof(HateoasLink<,>).MakeGenericType(
                         serviceType.GetGenericArguments()[0],
-                         typeof(IDomainEvent));
+                         typeof(IEvent));
                     var hateoasImplType = typeof(Dictionary<,>).MakeGenericType(typeof(Type), hateoasType);
                     var hateoasSvcType = typeof(IDictionary<,>).MakeGenericType(typeof(Type), hateoasType);
                     Type MakeSvcGenericType(Type type)
@@ -1484,8 +1481,8 @@ namespace BusinessApp.WebApi.IntegrationTest
             {
                 /* Arrange */
                 var linkFactory = A.Fake<Func<CommandStub, CompositeEventStub, string>>();
-                container.RegisterInstance<IDictionary<Type, HateoasLink<CommandStub, IDomainEvent>>>(
-                    new Dictionary<Type, HateoasLink<CommandStub, IDomainEvent>>());
+                container.RegisterInstance<IDictionary<Type, HateoasLink<CommandStub, IEvent>>>(
+                    new Dictionary<Type, HateoasLink<CommandStub, IEvent>>());
                 CreateRegistrations(container);
                 container.Verify();
                 var serviceType = typeof(IHttpRequestHandler<CommandStub, CompositeEventStub>);
@@ -1945,7 +1942,7 @@ namespace BusinessApp.WebApi.IntegrationTest
 #if DEBUG
         public sealed class CompositeEventStub : ICompositeEvent
         {
-            public IEnumerable<IDomainEvent> Events { get; set; }
+            public IEnumerable<IEvent> Events { get; set; }
         }
 #elif events
         public sealed class CompositeEventStub : ICompositeEvent

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/HateoasEventLinkTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/HateoasEventLinkTests.cs
@@ -39,7 +39,7 @@ namespace BusinessApp.WebApi.UnitTest
             public void RelativeLinkFactory_CastsToEvent()
             {
                 /* Arrange */
-                HateoasLink<RequestStub, IDomainEvent> link =  new EventLinkStub("next");
+                HateoasLink<RequestStub, IEvent> link =  new EventLinkStub("next");
                 var e = new EventStub() { Id = "foobar" };
 
                 /* Act */

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/Stubs.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/Stubs.cs
@@ -7,7 +7,7 @@ namespace BusinessApp.WebApi.UnitTest
     public enum EnumQueryStub { Foobar }
 
 #if DEBUG
-    public class EventStub : IDomainEvent
+    public class EventStub : IEvent
     {
         public string Id { get; set; }
         public DateTimeOffset OccurredUtc { get; }
@@ -15,7 +15,7 @@ namespace BusinessApp.WebApi.UnitTest
 
     public class CompoisteEventStub : ICompositeEvent
     {
-        public IEnumerable<IDomainEvent> Events { get; set; } = new List<IDomainEvent>();
+        public IEnumerable<IEvent> Events { get; set; } = new List<IEvent>();
     }
 #elif events
     public class EventStub : IDomainEvent

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/WeblinkingHeaderEventRequestDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/WeblinkingHeaderEventRequestDecoratorTests.cs
@@ -15,7 +15,7 @@ namespace BusinessApp.WebApi.UnitTest
     public class WeblinkingHeaderEventRequestDecoratorTests
     {
         private readonly IHttpRequestHandler<RequestStub, CompoisteEventStub> inner;
-        private IDictionary<Type, HateoasLink<RequestStub, IDomainEvent>> links;
+        private IDictionary<Type, HateoasLink<RequestStub, IEvent>> links;
         private WeblinkingHeaderEventRequestDecorator<RequestStub, CompoisteEventStub> sut;
 
         public WeblinkingHeaderEventRequestDecoratorTests()
@@ -23,9 +23,9 @@ namespace BusinessApp.WebApi.UnitTest
             inner = A.Fake<IHttpRequestHandler<RequestStub, CompoisteEventStub>>();
         }
 
-        public void Setup(IDictionary<Type, HateoasLink<RequestStub, IDomainEvent>> links = null)
+        public void Setup(IDictionary<Type, HateoasLink<RequestStub, IEvent>> links = null)
         {
-            this.links = links ?? new Dictionary<Type, HateoasLink<RequestStub, IDomainEvent>>();
+            this.links = links ?? new Dictionary<Type, HateoasLink<RequestStub, IEvent>>();
             sut = new WeblinkingHeaderEventRequestDecorator<RequestStub, CompoisteEventStub>(inner, this.links);
         }
 
@@ -38,12 +38,12 @@ namespace BusinessApp.WebApi.UnitTest
                     A.Dummy<IHttpRequestHandler<RequestStub, CompoisteEventStub>>(),
                     null,
                 },
-                new object[] { null, new Dictionary<Type, HateoasLink<RequestStub, IDomainEvent>>() },
+                new object[] { null, new Dictionary<Type, HateoasLink<RequestStub, IEvent>>() },
             };
 
             [Theory, MemberData(nameof(InvalidCtorArgs))]
             public void InvalidCtorArgs_ExceptionThrown(IHttpRequestHandler<RequestStub, CompoisteEventStub> i,
-                IDictionary<Type, HateoasLink<RequestStub, IDomainEvent>> d)
+                IDictionary<Type, HateoasLink<RequestStub, IEvent>> d)
             {
                 /* Arrange */
                 void shouldThrow() =>
@@ -91,7 +91,7 @@ namespace BusinessApp.WebApi.UnitTest
                 Setup();
                 var events = new CompoisteEventStub
                 {
-                    Events = A.CollectionOfDummy<IDomainEvent>(2)
+                    Events = A.CollectionOfDummy<IEvent>(2)
                 };
                 var innerResult = Result.Ok(HandlerContext.Create(A.Dummy<RequestStub>(), events));
                 A.CallTo(() => inner.HandleAsync(context, cancelToken))
@@ -109,7 +109,7 @@ namespace BusinessApp.WebApi.UnitTest
             public async Task HasEventLink_HeaderAdded()
             {
                 /* Arrange */
-                Setup(new Dictionary<Type, HateoasLink<RequestStub, IDomainEvent>>
+                Setup(new Dictionary<Type, HateoasLink<RequestStub, IEvent>>
                 {
                     { typeof(EventStub) ,new EventStubEventHateoasLink() { Title = "bar" } }
                 });
@@ -143,7 +143,7 @@ namespace BusinessApp.WebApi.UnitTest
             public async Task HasEventLinksWithExistingLinkHeader_HeadersAdded()
             {
                 /* Arrange */
-                Setup(new Dictionary<Type, HateoasLink<RequestStub, IDomainEvent>>
+                Setup(new Dictionary<Type, HateoasLink<RequestStub, IEvent>>
                 {
                     { typeof(EventStub) ,new EventStubEventHateoasLink() }
                 });
@@ -169,7 +169,7 @@ namespace BusinessApp.WebApi.UnitTest
                     headerValue);
             }
 
-            public class EventStub : IDomainEvent
+            public class EventStub : IEvent
             {
                 public int Id { get; set; }
                 public DateTimeOffset OccurredUtc { get; }

--- a/CSharp/src/BusinessApp.WebApi/HateoasEventLink.cs
+++ b/CSharp/src/BusinessApp.WebApi/HateoasEventLink.cs
@@ -8,14 +8,14 @@ namespace BusinessApp.WebApi
     /// </summary>
     /// <typeparam name="TRequest">The request type that triggered the event</typeparam>
     /// <typeparam name="TEvent">The event type</typeparam>
-    public abstract class HateoasEventLink<TRequest, TEvent> : HateoasLink<TRequest, IDomainEvent>
-        where TEvent : IDomainEvent
+    public abstract class HateoasEventLink<TRequest, TEvent> : HateoasLink<TRequest, IEvent>
+        where TEvent : IEvent
     {
         public HateoasEventLink(string rel)
             : base(rel)
         { }
 
-        public override Func<TRequest, IDomainEvent, string> RelativeLinkFactory
+        public override Func<TRequest, IEvent, string> RelativeLinkFactory
             => (r, e) => EventRelativeLinkFactory(r, (TEvent)e);
 
         protected abstract Func<TRequest, TEvent, string> EventRelativeLinkFactory { get; }

--- a/CSharp/src/BusinessApp.WebApi/TestResources.cs
+++ b/CSharp/src/BusinessApp.WebApi/TestResources.cs
@@ -87,10 +87,10 @@ namespace BusinessApp.WebApi
 #if DEBUG
         public class Response : ICompositeEvent
         {
-            public IEnumerable<IDomainEvent> Events { get; set; } = new List<IDomainEvent>();
+            public IEnumerable<IEvent> Events { get; set; } = new List<IEvent>();
         }
 
-        public class WebDomainEvent : IDomainEvent
+        public class WebDomainEvent : IEvent
         {
             public EntityId? Id { get; set; }
 
@@ -112,7 +112,6 @@ namespace BusinessApp.WebApi
         public class Response
         { }
 #endif
-
 #if DEBUG
         public class Handler : Infrastructure.IRequestHandler<Query, Response>,
             IEventHandler<WebDomainEvent>
@@ -130,12 +129,12 @@ namespace BusinessApp.WebApi
                 return Task.FromResult(Result.Ok(events));
             }
 
-            public Task<Result<IEnumerable<IDomainEvent>, Exception>> HandleAsync(
+            public Task<Result<IEnumerable<IEvent>, Exception>> HandleAsync(
                 WebDomainEvent e, CancellationToken cancelToken)
                 => webEvent == e
                     ? Task.FromResult(
-                        Result.Ok<IEnumerable<IDomainEvent>>(Array.Empty<IDomainEvent>()))
-                    : Task.FromResult(Result.Ok<IEnumerable<IDomainEvent>>(new[] { webEvent }));
+                        Result.Ok<IEnumerable<IEvent>>(Array.Empty<IEvent>()))
+                    : Task.FromResult(Result.Ok<IEnumerable<IEvent>>(new[] { webEvent }));
         }
 #elif events
         public class Handler : Infrastructure.IRequestHandler<Query, Response>,

--- a/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderEventRequestDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/WeblinkingHeaderEventRequestDecorator.cs
@@ -17,10 +17,10 @@ namespace BusinessApp.WebApi
        where TResponse : ICompositeEvent
     {
         private readonly IHttpRequestHandler<TRequest, TResponse> handler;
-        private readonly IDictionary<Type, HateoasLink<TRequest, IDomainEvent>> lookup;
+        private readonly IDictionary<Type, HateoasLink<TRequest, IEvent>> lookup;
 
         public WeblinkingHeaderEventRequestDecorator(IHttpRequestHandler<TRequest, TResponse> handler,
-            IDictionary<Type, HateoasLink<TRequest, IDomainEvent>> links)
+            IDictionary<Type, HateoasLink<TRequest, IEvent>> links)
         {
             this.handler = handler.NotNull().Expect(nameof(handler));
             lookup = links.NotNull().Expect(nameof(links));
@@ -53,7 +53,7 @@ namespace BusinessApp.WebApi
                         return okVal;
                     });
 
-        private bool HasLink((IDomainEvent e, Type eventType) eventLookup)
+        private bool HasLink((IEvent e, Type eventType) eventLookup)
             => lookup.TryGetValue(eventLookup.eventType, out var _);
     }
 }


### PR DESCRIPTION
* The event is from the `Kernel` project, not the old domain project. This
should have been renamed when the project was renamed.