### PR TITLE
fix(Events): Change CorrelationId to 1 to many with Metadata

### DIFF
--- a/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence.IntegrationTest/EFEventStoreFactoryTests.cs
@@ -16,7 +16,7 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
         private readonly IPrincipal user;
         private readonly BusinessAppDbContext db;
 
-        public EFEventStoreFactoryTests()
+        public EFEventStoreFactoryTests(DatabaseFixture fixture)
         {
             idFactory = A.Fake<IEntityIdFactory<MetadataId>>();
             db = A.Fake<BusinessAppDbContext>();
@@ -25,10 +25,14 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             sut = new EFEventStoreFactory(db, idFactory, user);
 
             A.CallTo(() => user.Identity.Name).Returns("foo");
+            A.CallTo(() => db.ChangeTracker).Returns(fixture.DbContext.ChangeTracker);
         }
 
         public class Constructor : EFEventStoreFactoryTests
         {
+            public Constructor(DatabaseFixture fixture) : base(fixture)
+            { }
+
             public static IEnumerable<object[]> InvalidCtorArgs => new[]
             {
                 new object[]
@@ -68,86 +72,137 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
 
         public class Create : EFEventStoreFactoryTests
         {
-            [Fact]
-            public void SetsMetadataId()
+            public Create(DatabaseFixture fixture) : base(fixture)
+            { }
+
+            public class WhenMetadataExists : EFEventStoreFactoryTests
             {
-                /* Arrange */
-                var id = A.Dummy<MetadataId>();
-                Metadata<object> metadata = null;
-                A.CallTo(() => idFactory.Create()).Returns(id);
-                A.CallTo(() => db.Add(A<Metadata<object>>._))
-                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                private readonly RequestStub trigger;
 
-                /* Act */
-                var _ = sut.Create(A.Dummy<object>());
+                public WhenMetadataExists(DatabaseFixture fixture) : base(fixture)
+                {
+                    trigger = new RequestStub();
+                }
 
-                /* Assert */
-                Assert.Equal(id, metadata.Id);
+                [Fact]
+                public void NotAddedToDb()
+                {
+                    /* Arrange */
+                    var metadata = new Metadata<RequestStub>(A.Dummy<MetadataId>(),
+                        "user", MetadataType.Request, trigger);
+                    db.ChangeTracker.Context.Add(metadata);
+
+                    /* Act */
+                    _ = sut.Create(trigger);
+
+                    /* Assert */
+                    A.CallTo(() => db.Add(A<Metadata<RequestStub>>._)).MustNotHaveHappened();
+                }
+
+                [Fact]
+                public void CorrlelationIdIsMetadataId()
+                {
+                    /* Arrange */
+                    var id = new MetadataId(1);
+                    var metadata = new Metadata<RequestStub>(id, "user", MetadataType.Request,
+                        trigger);
+                    db.ChangeTracker.Context.Add(metadata);
+                    var store = sut.Create(trigger);
+
+                    /* Act */
+                    var trackingId = store.Add(A.Dummy<IEvent>());
+
+                    /* Assert */
+                    Assert.Same(id, trackingId.CorrelationId);
+                }
             }
 
-            [Theory]
-            [InlineData("foouser", "foouser")]
-            [InlineData(null, "Anonymous")]
-            public void SetsMetadataUsername(string identityName, string setName)
+            public class WhenMetadataDoesNotExist : EFEventStoreFactoryTests
             {
-                /* Arrange */
-                Metadata<object> metadata = null;
-                A.CallTo(() => user.Identity.Name).Returns(identityName);
-                A.CallTo(() => db.Add(A<Metadata<object>>._))
-                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                public WhenMetadataDoesNotExist(DatabaseFixture fixture) : base(fixture)
+                { }
 
-                /* Act */
-                var _ = sut.Create(A.Dummy<object>());
+                [Fact]
+                public void SetsMetadataId()
+                {
+                    /* Arrange */
+                    var id = A.Dummy<MetadataId>();
+                    Metadata<object> metadata = null;
+                    A.CallTo(() => idFactory.Create()).Returns(id);
+                    A.CallTo(() => db.Add(A<Metadata<object>>._))
+                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                /* Assert */
-                Assert.Equal(setName, metadata.Username);
-            }
+                    /* Act */
+                    var _ = sut.Create(A.Dummy<object>());
 
-            [Fact]
-            public void NullIdentity_SetsAnonymousUsername()
-            {
-                /* Arrange */
-                Metadata<object> metadata = null;
-                A.CallTo(() => user.Identity).Returns(null);
-                A.CallTo(() => db.Add(A<Metadata<object>>._))
-                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                    /* Assert */
+                    Assert.Equal(id, metadata.Id);
+                }
 
-                /* Act */
-                var _ = sut.Create(A.Dummy<object>());
+                [Theory]
+                [InlineData("foouser", "foouser")]
+                [InlineData(null, "Anonymous")]
+                public void SetsMetadataUsername(string identityName, string setName)
+                {
+                    /* Arrange */
+                    Metadata<object> metadata = null;
+                    A.CallTo(() => user.Identity.Name).Returns(identityName);
+                    A.CallTo(() => db.Add(A<Metadata<object>>._))
+                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                /* Assert */
-                Assert.Equal(AnonymousUser.Name, metadata.Username);
-            }
+                    /* Act */
+                    _ = sut.Create(A.Dummy<object>());
 
-            [Fact]
-            public void SetsMetadataEventTriggerType()
-            {
-                /* Arrange */
-                Metadata<object> metadata = null;
-                A.CallTo(() => db.Add(A<Metadata<object>>._))
-                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                    /* Assert */
+                    Assert.Equal(setName, metadata.Username);
+                }
 
-                /* Act */
-                var _ = sut.Create(A.Dummy<object>());
+                [Fact]
+                public void NullIdentity_SetsAnonymousUsername()
+                {
+                    /* Arrange */
+                    Metadata<object> metadata = null;
+                    A.CallTo(() => user.Identity).Returns(null);
+                    A.CallTo(() => db.Add(A<Metadata<object>>._))
+                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                /* Assert */
-                Assert.Equal(MetadataType.EventTrigger.ToString(), metadata.TypeName);
-            }
+                    /* Act */
+                    _ = sut.Create(A.Dummy<object>());
 
-            [Fact]
-            public void SetsMetadataTrigger()
-            {
-                /* Arrange */
-                var trigger = A.Dummy<object>();
-                Metadata<object> metadata = null;
-                A.CallTo(() => db.Add(A<Metadata<object>>._))
-                    .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+                    /* Assert */
+                    Assert.Equal(AnonymousUser.Name, metadata.Username);
+                }
 
-                /* Act */
-                var _ = sut.Create(trigger);
+                [Fact]
+                public void SetsMetadataEventTriggerType()
+                {
+                    /* Arrange */
+                    Metadata<object> metadata = null;
+                    A.CallTo(() => db.Add(A<Metadata<object>>._))
+                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
 
-                /* Assert */
-                Assert.Same(trigger, metadata.Data);
+                    /* Act */
+                    _ = sut.Create(A.Dummy<object>());
+
+                    /* Assert */
+                    Assert.Equal(MetadataType.EventTrigger.ToString(), metadata.TypeName);
+                }
+
+                [Fact]
+                public void SetsMetadataTrigger()
+                {
+                    /* Arrange */
+                    var trigger = A.Dummy<object>();
+                    Metadata<object> metadata = null;
+                    A.CallTo(() => db.Add(A<Metadata<object>>._))
+                        .Invokes(c => metadata = c.GetArgument<Metadata<object>>(0));
+
+                    /* Act */
+                    _ = sut.Create(trigger);
+
+                    /* Assert */
+                    Assert.Same(trigger, metadata.Data);
+                }
             }
         }
 
@@ -156,7 +211,7 @@ namespace BusinessApp.Infrastructure.Persistence.IntegrationTest
             private readonly IEventStore store;
             private readonly MetadataId triggerId;
 
-            public Add()
+            public Add(DatabaseFixture fixture) : base(fixture)
             {
                 var trigger = A.Dummy<object>();
                 store = A.Fake<IEventStore>();

--- a/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
+++ b/CSharp/src/BusinessApp.Infrastructure.Persistence/EventMetadataEntityConfiguration.cs
@@ -41,11 +41,15 @@ namespace BusinessApp.Infrastructure.Persistence
                 .HasColumnType("datetimeoffset(0)")
                 .IsRequired();
 
-            builder.HasOne<Metadata>()
-                .WithOne()
-                .HasForeignKey<EventMetadata<T>>(e => e.CorrelationId);
+            builder.HasOne<Metadata<T>>()
+                .WithMany()
+                .HasForeignKey(e => e.CorrelationId)
+                .IsRequired()
+                .OnDelete(DeleteBehavior.Restrict);
 
             var owned = builder.OwnsOne(o => o.Event);
+
+            owned.Ignore(o => o.OccurredUtc);
 
             ConfigureEvent(owned);
         }

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.Designer.cs
@@ -44,8 +44,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CorrelationId")
-                        .IsUnique();
+                    b.HasIndex("CorrelationId");
 
                     b.ToTable("DeleteEvent", "evt");
                 });
@@ -136,7 +135,7 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.ToTable("ChildResponseStub");
                 });
 
-            modelBuilder.Entity("BusinessApp.Test.Shared.DomainEventStub", b =>
+            modelBuilder.Entity("BusinessApp.Test.Shared.EventStub", b =>
                 {
                     b.Property<long>("Id")
                         .HasColumnType("bigint");
@@ -146,7 +145,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("DomainEventStub");
+                    b.ToTable("EventStub");
                 });
 
             modelBuilder.Entity("BusinessApp.Test.Shared.RequestStub", b =>
@@ -232,6 +231,13 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.HasDiscriminator().HasValue("Metadata<Query>");
                 });
 
+            modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Infrastructure.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<WebDomainEvent>");
+                });
+
             modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
@@ -241,10 +247,10 @@ namespace BusinessApp.Test.Shared.Migrations
 
             modelBuilder.Entity("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
                 {
-                    b.HasOne("BusinessApp.Infrastructure.Metadata", null)
-                        .WithOne()
-                        .HasForeignKey("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", "CorrelationId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                    b.HasOne("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", null)
+                        .WithMany()
+                        .HasForeignKey("CorrelationId")
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.OwnsOne("BusinessApp.WebApi.Delete+WebDomainEvent", "Event", b1 =>

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/20210318173620_CreateTestDb.cs
@@ -26,7 +26,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "DomainEventStub",
+                name: "EventStub",
                 columns: table => new
                 {
                     Id = table.Column<long>(type: "bigint", nullable: false),
@@ -34,7 +34,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_DomainEventStub", x => x.Id);
+                    table.PrimaryKey("PK_EventStub", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -121,7 +121,7 @@ namespace BusinessApp.Test.Shared.Migrations
                         principalSchema: "dbo",
                         principalTable: "Metadata",
                         principalColumn: "MetadataId",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
             migrationBuilder.CreateTable(
@@ -195,8 +195,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 name: "IX_DeleteEvent_CorrelationId",
                 schema: "evt",
                 table: "DeleteEvent",
-                column: "CorrelationId",
-                unique: true);
+                column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_DeleteQuery_MetadataId",
@@ -232,7 +231,7 @@ namespace BusinessApp.Test.Shared.Migrations
                 name: "DeleteQuery");
 
             migrationBuilder.DropTable(
-                name: "DomainEventStub");
+                name: "EventStub");
 
             migrationBuilder.DropTable(
                 name: "PostOrPutBody");

--- a/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
+++ b/CSharp/src/BusinessApp.Test.Shared/Migrations/BusinessAppTestDbContextModelSnapshot.cs
@@ -42,8 +42,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CorrelationId")
-                        .IsUnique();
+                    b.HasIndex("CorrelationId");
 
                     b.ToTable("DeleteEvent", "evt");
                 });
@@ -134,7 +133,7 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.ToTable("ChildResponseStub");
                 });
 
-            modelBuilder.Entity("BusinessApp.Test.Shared.DomainEventStub", b =>
+            modelBuilder.Entity("BusinessApp.Test.Shared.EventStub", b =>
                 {
                     b.Property<long>("Id")
                         .HasColumnType("bigint");
@@ -144,7 +143,7 @@ namespace BusinessApp.Test.Shared.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("DomainEventStub");
+                    b.ToTable("EventStub");
                 });
 
             modelBuilder.Entity("BusinessApp.Test.Shared.RequestStub", b =>
@@ -230,6 +229,13 @@ namespace BusinessApp.Test.Shared.Migrations
                     b.HasDiscriminator().HasValue("Metadata<Query>");
                 });
 
+            modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
+                {
+                    b.HasBaseType("BusinessApp.Infrastructure.Metadata");
+
+                    b.HasDiscriminator().HasValue("Metadata<WebDomainEvent>");
+                });
+
             modelBuilder.Entity("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.PostOrPut+Body>", b =>
                 {
                     b.HasBaseType("BusinessApp.Infrastructure.Metadata");
@@ -239,10 +245,10 @@ namespace BusinessApp.Test.Shared.Migrations
 
             modelBuilder.Entity("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", b =>
                 {
-                    b.HasOne("BusinessApp.Infrastructure.Metadata", null)
-                        .WithOne()
-                        .HasForeignKey("BusinessApp.Infrastructure.EventMetadata<BusinessApp.WebApi.Delete+WebDomainEvent>", "CorrelationId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                    b.HasOne("BusinessApp.Infrastructure.Metadata<BusinessApp.WebApi.Delete+WebDomainEvent>", null)
+                        .WithMany()
+                        .HasForeignKey("CorrelationId")
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.OwnsOne("BusinessApp.WebApi.Delete+WebDomainEvent", "Event", b1 =>


### PR DESCRIPTION
* The correlation id ties together commands that create events and other
events. Therefore, the relationship to the metadata through the
correlation id is a one to many because many events can be correlated to
one metadata
* Fix metadata event tracking. Multiple events tied to the same request
was creating extra metadata records rather than relating it to the same
metadata already in the `DbContext`. Check to see if metadata
exists before adding a new event metadata to keep the relationship