### PR TITLE
feat(ProblemDetail): Add `StatusCodeException` base class

### DIFF
--- a/CSharp/src/BusinessApp.WebApi.UnitTest/Json/JsonHttpDecoratorTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/Json/JsonHttpDecoratorTests.cs
@@ -8,6 +8,7 @@ using BusinessApp.WebApi.Json;
 using FakeItEasy;
 using Microsoft.AspNetCore.Http;
 using Xunit;
+using BusinessApp.WebApi.ProblemDetails;
 
 namespace BusinessApp.WebApi.UnitTest.Json
 {
@@ -65,8 +66,7 @@ namespace BusinessApp.WebApi.UnitTest.Json
             public async Task NotValidContent_ResultErrorReturned(string method)
             {
                 /* Arrange */
-                var error = new BusinessAppException(
-                    "Expected content-type to be application/json");
+                var errorMsg = "Expected content-type to be application/json";
                 A.CallTo(() => context.Request.ContentType).Returns("text");
                 A.CallTo(() => context.Request.Method).Returns(method);
 
@@ -74,11 +74,12 @@ namespace BusinessApp.WebApi.UnitTest.Json
                 var result = await sut.HandleAsync(context, cancelToken);
 
                 /* Assert */
-                Assert.Equal(error.Message, result.UnwrapError().Message);
+                var error = result.UnwrapError();
+                Assert.Equal(errorMsg, result.UnwrapError().Message);
             }
 
             [Theory, MemberData(nameof(SaveMethods))]
-            public async Task NotValidContent_UnsupportedMediaResponseSet(string method)
+            public async Task NotValidContent_UnsupportedMediaResponseExceptionThrown(string method)
             {
                 /* Arrange */
                 A.CallTo(() => context.Request.ContentType).Returns("text");
@@ -88,8 +89,8 @@ namespace BusinessApp.WebApi.UnitTest.Json
                 var result = await sut.HandleAsync(context, cancelToken);
 
                 /* Assert */
-                A.CallToSet(() => context.Response.StatusCode).To(415)
-                    .MustHaveHappenedOnceExactly();
+                var error = result.UnwrapError();
+                Assert.IsType<UnsupportedMediaTypeException>(error);
             }
 
             [Fact]

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailFactoryTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/ProblemDetailFactoryTests.cs
@@ -55,7 +55,7 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
         public class Create : ProblemDetailFactoryTests
         {
             [Fact]
-            public void NullArgument_ExceptionThrown()
+            public void NullException_ExceptionThrown()
             {
                 /* Arrange */
                 Exception unknown = null;
@@ -257,6 +257,32 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
 
                 /* Assert */
                 Assert.Equal("", problem["bar"]);
+            }
+
+            [Fact]
+            public void WhenStatusCodeException_ThatStatusUsed()
+            {
+                /* Arrange */
+                var error = new StatusCodeExceptionStub();
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.Equal(400, problem.StatusCode);
+            }
+
+            [Fact]
+            public void WhenStatusCodeException_ThatMessageUsed()
+            {
+                /* Arrange */
+                var error = new StatusCodeExceptionStub();
+
+                /* Act */
+                var problem = sut.Create(error);
+
+                /* Assert */
+                Assert.Equal("foo", problem.Detail);
             }
 
 #if DEBUG
@@ -573,6 +599,12 @@ namespace BusinessApp.WebApi.UnitTest.ProblemDetails
         private sealed class AnotherProblemTypeExceptionStub : Exception
         {
             public AnotherProblemTypeExceptionStub(string msg = null) : base(msg)
+            {}
+        }
+
+        private sealed class StatusCodeExceptionStub : StatusCodeException
+        {
+            public StatusCodeExceptionStub() : base(400, "foo")
             {}
         }
 

--- a/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/UnsupportedMediaTypeExceptionTests.cs
+++ b/CSharp/src/BusinessApp.WebApi.UnitTest/ProblemDetails/UnsupportedMediaTypeExceptionTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using BusinessApp.Kernel;
+using BusinessApp.WebApi.ProblemDetails;
+using Xunit;
+
+namespace BusinessApp.WebApi.UnitTest.ProblemDetails
+{
+    public class UnsupportedMediaTypeExceptionTests
+    {
+        public class Constructor : UnsupportedMediaTypeExceptionTests
+        {
+            public static IEnumerable<object[]> InvalidArgs => new[]
+            {
+                new object[] { null },
+                new object[] { "" },
+                new object[] { " " },
+            };
+
+            [Theory, MemberData(nameof(InvalidArgs))]
+            public void InvalidArgs_ExceptionThrown(string m)
+            {
+                /* Arrange */
+                void shouldThrow() => new UnsupportedMediaTypeException(m);
+
+                /* Act */
+                var ex = Record.Exception(shouldThrow);
+
+                /* Assert */
+                Assert.IsType<BusinessAppException>(ex);
+            }
+        }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
+++ b/CSharp/src/BusinessApp.WebApi/Json/JsonHttpDecorator.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using BusinessApp.Kernel;
 using System.Threading;
+using BusinessApp.WebApi.ProblemDetails;
 
 namespace BusinessApp.WebApi.Json
 {
@@ -25,10 +26,8 @@ namespace BusinessApp.WebApi.Json
 
             if (context.Request.MayHaveContent() && !validContentType)
             {
-                context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
-
                 return Result.Error<HandlerContext<TRequest, TResponse>>(
-                    new BusinessAppException("Expected content-type to be application/json"));
+                    new UnsupportedMediaTypeException("Expected content-type to be application/json"));
             }
 
             try

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
@@ -43,12 +43,6 @@ namespace BusinessApp.WebApi.ProblemDetails
                     "Your request was rejected because of bad data. Please review your " +
                     "request before resubmission."
             },
-            new ProblemDetailOptions(typeof(TaskCanceledException), StatusCodes.Status400BadRequest)
-            {
-                MessageOverride =
-                    "Your request has been cancelled. This is most likely due to a bad request. " +
-                    "If more details are not provided check the state of your date and retry the request."
-            },
             new ProblemDetailOptions(typeof(ModelValidationException), StatusCodes.Status400BadRequest),
             new ProblemDetailOptions(typeof(SecurityException), StatusCodes.Status403Forbidden)
             {

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/Bootstrap.cs
@@ -7,6 +7,7 @@ using BusinessApp.Infrastructure;
 using BusinessApp.Kernel;
 using Microsoft.AspNetCore.Http;
 using SimpleInjector;
+using System.Net.Http;
 
 namespace BusinessApp.WebApi.ProblemDetails
 {
@@ -15,7 +16,7 @@ namespace BusinessApp.WebApi.ProblemDetails
     /// </summary>
     public static partial class ProblemDetailOptionBootstrap
     {
-        public static HashSet<ProblemDetailOptions> knownProblems = new()
+        private static readonly HashSet<ProblemDetailOptions> knownProblems = new()
         {
             new ProblemDetailOptions(typeof(ActivationException), StatusCodes.Status404NotFound)
             {
@@ -71,7 +72,9 @@ namespace BusinessApp.WebApi.ProblemDetails
             {
                 MessageOverride = "The application does not support this business workflow."
             },
-            new ProblemDetailOptions(typeof(CommunicationException), StatusCodes.Status424FailedDependency)
+            new ProblemDetailOptions(typeof(CommunicationException), StatusCodes.Status424FailedDependency),
+            new ProblemDetailOptions(typeof(HttpRequestException), StatusCodes.Status502BadGateway),
+            new ProblemDetailOptions(typeof(TaskCanceledException), StatusCodes.Status503ServiceUnavailable)
         };
 
         public static void AddProblem(ProblemDetailOptions options) => _ = knownProblems.Add(options);

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/StatusCodeException.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/StatusCodeException.cs
@@ -1,0 +1,18 @@
+using System;
+using BusinessApp.Kernel;
+
+namespace BusinessApp.WebApi.ProblemDetails
+{
+    public abstract class StatusCodeException : Exception
+    {
+        public StatusCodeException(int statusCode, string message)
+            : base(message)
+        {
+            _ = message.NotEmpty().Expect(nameof(message));
+
+            StatusCode = statusCode;
+        }
+
+        public int StatusCode { get; }
+    }
+}

--- a/CSharp/src/BusinessApp.WebApi/ProblemDetails/UnsupportedMediaTypeException.cs
+++ b/CSharp/src/BusinessApp.WebApi/ProblemDetails/UnsupportedMediaTypeException.cs
@@ -1,0 +1,9 @@
+namespace BusinessApp.WebApi.ProblemDetails
+{
+    public class UnsupportedMediaTypeException : StatusCodeException
+    {
+        public UnsupportedMediaTypeException(string message)
+            : base(415, message)
+        { }
+    }
+}


### PR DESCRIPTION
Add a `StatusCodeException` that maps to a status code. When creating a
`ProblemDetail` when can check this exception for the appropriate status
code instead of defaulting to a 500. Benefit of this is that the status
code is set it only one place, the `HttpResponseDecorator`

Map `HttpRequestException` and timeout