### PR TITLE
fix(grouping): Await scoped group batch requests

### DIFF
--- a/CSharp/src/BusinessApp.CompositionRoot/MainRegister.cs
+++ b/CSharp/src/BusinessApp.CompositionRoot/MainRegister.cs
@@ -248,12 +248,11 @@ namespace BusinessApp.CompositionRoot
                 typeof(GroupedBatchRequestDecorator<,>),
                 c => c.ImplementationType.IsTypeDefinition(typeof(AuthorizationRequestDecorator<,>)));
 #elif hasbatch
-            // Apply this as a decorator for batch requests before the ScopeBatchRequestProxy
-            // Need the conditional registration for macro requests
             context.Container.RegisterDecorator(
                 serviceType,
                 typeof(GroupedBatchRequestDecorator<,>),
-                c => c.ImplementationType.IsTypeDefinition(typeof(AuthorizationRequestDecorator<,>)));
+                c => CanHandle(c)
+                    && c.ImplementationType.IsTypeDefinition(typeof(AuthorizationRequestDecorator<,>)));
 #endif
 
 #if DEBUG

--- a/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorScopedBatchRequestProxy.cs
+++ b/CSharp/src/BusinessApp.CompositionRoot/SimpleInjectorScopedBatchRequestProxy.cs
@@ -26,12 +26,14 @@ namespace BusinessApp.CompositionRoot
             this.factory = factory.NotNull().Expect(nameof(factory));
         }
 
-        public Task<Result<TResponse, Exception>> HandleAsync(IEnumerable<TRequest> request,
+        public async Task<Result<TResponse, Exception>> HandleAsync(IEnumerable<TRequest> request,
             CancellationToken cancelToken)
         {
             using var _ = AsyncScopedLifestyle.BeginScope(container);
+
             var inner = factory();
-            return inner.HandleAsync(request, cancelToken);
+
+            return await inner.HandleAsync(request, cancelToken);
         }
     }
 }

--- a/CSharp/src/BusinessApp.WebApi/TestResources.cs
+++ b/CSharp/src/BusinessApp.WebApi/TestResources.cs
@@ -74,6 +74,27 @@ namespace BusinessApp.WebApi
         {
             public long LongerId { get; set; }
             public EntityId? Id { get; set; }
+
+            public override bool Equals(object unknown)
+            {
+                if (unknown is PostOrPut.Body other)
+                {
+                    return LongerId.Equals(other.LongerId);
+                }
+
+                return base.Equals(unknown);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 23 + LongerId.GetHashCode();
+
+                    return hash;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
* Await calls in `SimpleInjectorScopedBatchRequestProxy` or else the
scope will dispose along with all services before they can finish. The
call awaits in the group decorator, but the scope will be disposed
already
* Fix grouping registration or else a cyclic dependency error is thrown
* Add tests to ensure this grouping works as expected